### PR TITLE
NBCR-2023-001: use reverse DNS notation in the URI format

### DIFF
--- a/papers/nbcr-2023-001-coin-identity.md
+++ b/papers/nbcr-2023-001-coin-identity.md
@@ -3,8 +3,8 @@
 
 **© 2023 Ngrave**
 
-Authors: İrfan Bilaloğlu, Mathieu Da Silva<br/>
-Date: 19 April 2023<br/>
+Authors: İrfan Bilaloğlu, Mathieu Da Silva, Maher Sallam<br/>
+Date: 17 September 2024<br/>
 
 ---
 

--- a/papers/nbcr-2023-001-coin-identity.md
+++ b/papers/nbcr-2023-001-coin-identity.md
@@ -86,27 +86,25 @@ subtype = 3
 
 The UR type is designed to be easily convertible to a URI format when human readability or deep linking are required.
 
-The URI format is as follows: **`bc-coin://{subtype1.subtype0}.{curve}/type?optional=parameters`**.
+The URI format is as follows: **`bc-coin://curve.type[.subtype1.subtype2][?optional=parameters]`**. This format uses the reverse DNS notation because it groups closely related coins when sorting them lexically.
 
-
-We are providing several examples in the following table:
+The following table provides several examples:
 
 | Coin | URI coin identity |
 | --- | --- |
-| Bitcoin (BTC) | bc-coin://secp256k1/0 |
-| Ethereum (ETH) | bc-coin://secp256k1/60 |
-| Polygon (MATIC) | bc-coin://137.secp256k1/60 |
-| Solana (SOL) | bc-coin://ed25519/508 |
-| Tezos (XTZ) based on ed25519 | bc-coin://ed25519/1729 |
-| Tezos (XTZ) based on secp256k1 | bc-coin://secp256k1/1729 |
-| Neo | bc-coin://p256/888 |
-| Polkadot | bc-coin://x25519/354 |
-
+| Bitcoin (BTC) | bc-coin://secp256k1.0 |
+| Ethereum (ETH) | bc-coin://secp256k1.60 |
+| Polygon (POL) | bc-coin://secp256k1.60.137 |
+| Solana (SOL) | bc-coin://ed25519.508 |
+| Tezos (XTZ) based on ed25519 | bc-coin://ed25519.1729 |
+| Tezos (XTZ) based on secp256k1 | bc-coin://secp256k1.1729 |
+| Neo | bc-coin://p256.888 |
+| Polkadot | bc-coin://x25519.354 |
 
 ### Example/Test Vector 1
 
-* Solana coin 
-* URI: `bc-coin://ed25519/501`
+* Solana coin
+* URI: `bc-coin://ed25519.501`
 
 * In the CBOR diagnostic notation:
 
@@ -116,7 +114,6 @@ We are providing several examples in the following table:
    2: 501, ; type Solana BIP44
 }
 ```
-
 
 * Encoded as binary using [CBOR-PLAYGROUND]:
 
@@ -147,8 +144,8 @@ ur:crypto-eckey/oeaoykaxhdcxlkahssqzwfvslofzoxwkrewngotktbmwjkwdcmnefsaaehrlolks
 
 ### Example/Test Vector 2
 
-- Polygon coin, ETH with a different chain ID.
-- URI: `bc-coin://137.secp256k1/60`
+* Polygon coin, ETH with a different chain ID.
+* URI: `bc-coin://secp256k1.60.137`
 
 * In the CBOR diagnostic notation:
 


### PR DESCRIPTION
As discussed today during the sync meeting, this PR changes the URI format of the Coin Identity to use the reverse DNS notation.

Rationale: in the current format, the `subtype`s precede the `curve` and are in the same section, giving the impression that they are `subtype`s of the curve.

Another nice property of this reverse DNS notation is that it groups closely related coins when sorting them lexically.