### PR TITLE
New UR tags and name update

### DIFF
--- a/papers/nbcr-2023-001-coin-identity.md
+++ b/papers/nbcr-2023-001-coin-identity.md
@@ -6,11 +6,13 @@
 Authors: İrfan Bilaloğlu, Mathieu Da Silva, Maher Sallam<br/>
 Date: 18 September 2024<br/>
 
+Revised: October 04, 2024
+
 ---
 
 ### Introduction
 
-In this document, we are defining the new UR type `crypto-coin-identity` based on new types and COSE constants defined in [[RFC9053]](https://www.rfc-editor.org/rfc/rfc9053.html).
+In this document, we are defining the new UR type `coin-identity` based on new types and COSE constants defined in [[RFC9053]](https://www.rfc-editor.org/rfc/rfc9053.html).
 
 We propose to define a UR type standardizing the coin identification by aggregating the following information:
 
@@ -41,7 +43,7 @@ The required `type` field carries the coin type information as defined in [[SLIP
 
 ### CDDL
 
-The following specification of `crypto-coin-identity` is written in CDDL. When used embedded in another CBOR structure, this structure should be tagged #6.1401.
+The following specification of `coin-identity` is written in CDDL. When used embedded in another CBOR structure, this structure should be tagged #6.41401.
 
 ```
 ; Table should always be updated according to IANA registry 
@@ -105,7 +107,7 @@ A201080200
 * As a UR:
 
 ```
-ur:crypto-coin-identity/hdadbraoae
+ur:coin-identity/hdadbraoae
 ```
 
 ### Example/Test Vector 2: Solana (SOL)
@@ -139,7 +141,7 @@ A20106021901F5
 * As a UR:
 
 ```
-ur:crypto-coin-identity/hdadbdaoftadpk
+ur:coin-identity/hdadbdaoftadpk
 ```
 
 
@@ -178,7 +180,7 @@ A3010802183C03811889
 * As a UR:
 
 ```
-ur:crypto-coin-identity/hgadbraoetpsatenetfd
+ur:coin-identity/hgadbraoetpsatenetfd
 ```
 
 

--- a/papers/nbcr-2023-002-multi-layer-sync.md
+++ b/papers/nbcr-2023-002-multi-layer-sync.md
@@ -108,7 +108,7 @@ Finally we propose in this document a third layer based on the `crypto-portfolio
 | `multi-account` | 41103 | Ngrave | Import multiple accounts in one animated QR | This document |
 | (Deprecated) `crypto-multi-account` | 1103 | Keystone | Previous version of Import multiple accounts in one animated QR | [[solana-qr-data-protocol]](https://github.com/KeystoneHQ/Keystone-developer-hub/blob/main/research/solana-qr-data-protocol.md#setup-watch-only-wallet-by-offline-signer) |
 | `coin-identity` | 41401 | Ngrave | Add additional information to a specific hdkey | [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md) |
-| `crypto-detailed-account` | 1402 | Ngrave | Import multiple accounts with and without output descriptors and specify optionally tokens to synchronize | This document |
+| `detailed-account` | 41402 | Ngrave | Import multiple accounts with and without output descriptors and specify optionally tokens to synchronize | This document |
 | `crypto-portfolio-coin` | 1403 | Ngrave | Associate several accounts to its coin identity  | This document |
 | `crypto-portfolio-metadata` | 1404 | Ngrave | Specify wallet metadata | This document |
 | `crypto-portfolio` | 1405 | Ngrave | Aggregate the portfolio information | This document |
@@ -453,7 +453,7 @@ device = 3
 
 The third layer of the proposed sync protocol is based on `crypto-portfolio` UR type, aiming to synchronize the accounts related to multiple coins.
 
-We break down its structure in Figure 5 based on newly defined UR types: `crypto-portfolio-coin`, `coin-identity`, `crypto-detailed-account` and `crypto-portfolio-metadata`. The CDDL for the new UR types are given hereafter.
+We break down its structure in Figure 5 based on newly defined UR types: `crypto-portfolio-coin`, `coin-identity`, `detailed-account` and `crypto-portfolio-metadata`. The CDDL for the new UR types are given hereafter.
 
 ```mermaid
 flowchart TB
@@ -479,11 +479,11 @@ flowchart TB
     direction TB
 	Coins --> ID[(coin-identity)]
     Coins -.-> MF2[master-fingerprint]
-	Coins --> DetAcc[[crypto-detailed-account]]
+	Coins --> DetAcc[[detailed-account]]
     end
 
-    %% crypto-detailed-account breakdown
-    subgraph crypto-detailed-account
+    %% detailed-account breakdown
+    subgraph detailed-account
     direction TB
     DetAcc --> key{Account}
 	key --> HD[(hdkey)]
@@ -501,16 +501,16 @@ flowchart TB
 ```
 Figure 5. Breakdown of crypto-portfolio forming the layer 3 of the sync protocol
 
-- **CDDL for synchronizing several accounts with detailed information** `crypto-detailed-account`
+- **CDDL for synchronizing several accounts with detailed information** `detailed-account`
 
-In this document, we are defining the new `crypto-detailed-account` UR type, extending the scope of the previously defined `account` and `multi-account` UR types in [UR registry constituting the layer 2](nbcr-2023-002-multi-layer-sync.md#ur-registry-constituting-the-layer-2). The information contained in the layer 2 sync protocol can be easily converted to `crypto-detailed-account` type.
+In this document, we are defining the new `detailed-account` UR type, extending the scope of the previously defined `account` and `multi-account` UR types in [UR registry constituting the layer 2](nbcr-2023-002-multi-layer-sync.md#ur-registry-constituting-the-layer-2). The information contained in the layer 2 sync protocol can be easily converted to `detailed-account` type.
 
 This new type aims to incorporate in the same structure:
 
-- The accounts with and without scripts by selecting either `hdkey` or `output-descriptor`. When a `hdkey` is embedded inside `crypto-detailed-account`, the optional `coin-info` in `hdkey` should **not** be defined since `crypto-detailed-account` is used in combination with `coin-identity` used already as asset identifier. 
+- The accounts with and without scripts by selecting either `hdkey` or `output-descriptor`. When a `hdkey` is embedded inside `detailed-account`, the optional `coin-info` in `hdkey` should **not** be defined since `detailed-account` is used in combination with `coin-identity` used already as asset identifier. 
 - An optional list of tokens to synchronize them at the same time of the associated account. A token identifier is defined as a string or tagged with #6.263 to specify a [[hexString]](https://github.com/toravir/CBOR-Tag-Specs/blob/master/hexString.md).
 
-The following specification of `crypto-detailed-account` is written in CDDL. When used embedded in another CBOR structure, this structure should be tagged #6.1402.
+The following specification of `detailed-account` is written in CDDL. When used embedded in another CBOR structure, this structure should be tagged #6.41402.
 
 ```
 account_exp = #6.40303(hdkey) / #6.40308(output-descriptor)
@@ -549,7 +549,7 @@ token-ids = 2
 
 - **CDDL for synchronizing accounts with their coin identity** `crypto-portfolio-coin`
 
-In this document, we are defining the new `crypto-portfolio-coin` UR type associating the `coin-identity` defined in [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md) with their accounts. The accounts are preferably defined using a list of `crypto-detailed-account`. 
+In this document, we are defining the new `crypto-portfolio-coin` UR type associating the `coin-identity` defined in [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md) with their accounts. The accounts are preferably defined using a list of `detailed-account`. 
 
 To keep full compatibility with the layer 2, the accounts can also be specified using `account` and `crypto-multi-account` UR types. Using these UR types will however limit the information which can be synchronized.
 
@@ -558,9 +558,9 @@ The following specification of `crypto-portfolio-coin` is written in CDDL. When 
 ```
 ; Associate a coin identity to its accounts
 
-detailed_accounts = [+ #6.1402(crypto-detailed-account)]
+detailed_accounts = [+ #6.41402(detailed-account)]
 
-; The accounts are listed using #6.1402(crypto-detailed-account) to share the maximum of information related to the accounts
+; The accounts are listed using #6.41402(detailed-account) to share the maximum of information related to the accounts
 
 coin = {
   coin-id: #6.41401(coin-identity),
@@ -613,7 +613,7 @@ When used embedded in another CBOR structure, this structure should be tagged #6
 ; Top level multi coin sync payload
 
 sync = {
-		coins: [+ #6.1402(crypto-portfolio-coin)],           ; Multiple coins with their respective accounts and coin identities
+		coins: [+ #6.41402(crypto-portfolio-coin)],           ; Multiple coins with their respective accounts and coin identities
 		? metadata: #6.1403(crypto-portfolio-metadata) ; Optional wallet metadata
 }
 
@@ -935,7 +935,7 @@ ur:crypto-multi-accounts/hgadfwnehnntlgaofelegtcdhdatbkhkaofmspcthepyjnrkdtmhasb
 
 Compared to the first and second layers of the sync protocol, the third layer is made for every watch-only wallets aiming to support any coins, representing the generic case how NGRAVE ZERO offline signer and NGRAVE LIQUID app are functioning. The `crypto-portfolio` UR type includes multiple coins/blockchains based on different elliptic curves. 
 
-The accounts of each coin are described using a list of `crypto-detailed-account` indicating a public key or extended public key, a derivation path, a potential script type and a potential list of tokens associated to the account.
+The accounts of each coin are described using a list of `detailed-account` indicating a public key or extended public key, a derivation path, a potential script type and a potential list of tokens associated to the account.
 
 The accounts are always grouped under a coin identity with the `coin-identity` UR type.
 
@@ -991,7 +991,7 @@ An example illustrates how the sync payload is formed using the third layer of c
          2: 60, ; Ethereum BIP44
          3: [ 1 ] ; Ethereum chain ID
         }),
-    2: [1402( ; #6.1402(crypto-detailed-account)
+    2: [41402( ; #6.41402(detailed-account)
         {1: 40303( ; #6.40303(hdkey)
            {3: h'032503D7DCA4FF0594F0404D56188542A18D8E0784443134C716178BC1819C3DD4', ; key-data
             4: h'719EA8CADCA1BBC71BF8511AC3A487286B4D34A860007B8FD498F2732EB89906', ; chain-code
@@ -1006,14 +1006,14 @@ An example illustrates how the sync payload is formed using the third layer of c
         {1: 6, ; ed25519 curve
          2: 501 ; Solana BIP44
         }),
-    2: [1402( ; #6.1402(crypto-detailed-account)
+    2: [41402( ; #6.41402(detailed-account)
         {1: 40303(  ; #6.40303(hdkey)
            {3: h'02EAE4B876A8696134B868F88CC2F51F715F2DBEDB7446B8E6EDF3D4541C4EB67B', ; key-data
             6: 304({1: [44, true, 501, true, 0, true, 0, true]}) ; origin m/44’/501’/0’/0’
           }),
         2: [ "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" ] ; USDC SPL token
        }),
-	   1402( ; #6.1402(crypto-detailed-account)
+	   41402( ; #6.41402(detailed-account)
         {1: 40303(  ; #6.40303(hdkey)
            {3: h'0260563EE80C26844621B06B74070BAF0E23FB76CE439D0237E87502EBBD3CA346', ; key-data
             6: 40304({1: [44, true, 501, true, 0, true, 1, true]}) ; origin m/44’/501’/0’/1’
@@ -1026,7 +1026,7 @@ An example illustrates how the sync payload is formed using the third layer of c
          2: 60, ; Ethereum BIP44
          3: [ 137 ] ; Polygon chain ID
         }),
-    2: [1402( ; #6.1402(crypto-detailed-account)
+    2: [41402( ; #6.41402(detailed-account)
         {1: 40303(  ; #6.40303(hdkey)
            {3: h'032503D7DCA4FF0594F0404D56188542A18D8E0784443134C716178BC1819C3DD4', ; key-data
             4: h'719EA8CADCA1BBC71BF8511AC3A487286B4D34A860007B8FD498F2732EB89906', ; chain-code
@@ -1041,7 +1041,7 @@ An example illustrates how the sync payload is formed using the third layer of c
         {1: 8, ; secp256k1 curve
          2: 0 ; Bitcoin BIP44
         }),
-    2: [1402( ; #6.1402(crypto-detailed-account)
+    2: [41402( ; #6.41402(detailed-account)
          {1: 40308({ ; output-descriptor
             1: "pkh(@0)", ; source (text descriptor)
             2: [ ; keys array
@@ -1052,7 +1052,7 @@ An example illustrates how the sync payload is formed using the third layer of c
                   8: 2583285239 ; parent fingerprint
             })]	 
 	     })}),
-         1402( ; #6.1402(crypto-detailed-account)
+         41402( ; #6.441402(detailed-account)
          {1: 40308({ ; output-descriptor
             1: "sh(wpkh(@0))", ; source (text descriptor)
             2: [ ; keys array

--- a/papers/nbcr-2023-002-multi-layer-sync.md
+++ b/papers/nbcr-2023-002-multi-layer-sync.md
@@ -109,7 +109,7 @@ Finally we propose in this document a third layer based on the `crypto-portfolio
 | (Deprecated) `crypto-multi-account` | 1103 | Keystone | Previous version of Import multiple accounts in one animated QR | [[solana-qr-data-protocol]](https://github.com/KeystoneHQ/Keystone-developer-hub/blob/main/research/solana-qr-data-protocol.md#setup-watch-only-wallet-by-offline-signer) |
 | `coin-identity` | 41401 | Ngrave | Add additional information to a specific hdkey | [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md) |
 | `detailed-account` | 41402 | Ngrave | Import multiple accounts with and without output descriptors and specify optionally tokens to synchronize | This document |
-| `crypto-portfolio-coin` | 1403 | Ngrave | Associate several accounts to its coin identity  | This document |
+| `portfolio-coin` | 41403 | Ngrave | Associate several accounts to its coin identity  | This document |
 | `crypto-portfolio-metadata` | 1404 | Ngrave | Specify wallet metadata | This document |
 | `crypto-portfolio` | 1405 | Ngrave | Aggregate the portfolio information | This document |
 
@@ -453,7 +453,7 @@ device = 3
 
 The third layer of the proposed sync protocol is based on `crypto-portfolio` UR type, aiming to synchronize the accounts related to multiple coins.
 
-We break down its structure in Figure 5 based on newly defined UR types: `crypto-portfolio-coin`, `coin-identity`, `detailed-account` and `crypto-portfolio-metadata`. The CDDL for the new UR types are given hereafter.
+We break down its structure in Figure 5 based on newly defined UR types: `portfolio-coin`, `coin-identity`, `detailed-account` and `crypto-portfolio-metadata`. The CDDL for the new UR types are given hereafter.
 
 ```mermaid
 flowchart TB
@@ -461,7 +461,7 @@ flowchart TB
 	Sync[(crypto-portfolio)]
 	subgraph crypto-portfolio
     direction TB
-	Sync --> Coins[[crypto-portfolio-coin]]
+	Sync --> Coins[[portfolio-coin]]
 	Sync -.-> Meta[(crypto-portfolio-metadata)]
     end
 
@@ -474,8 +474,8 @@ flowchart TB
 	Meta -...-> device
 	end
 
-	%% crypto-portfolio-coin breakdown
-	subgraph crypto-portfolio-coin
+	%% portfolio-coin breakdown
+	subgraph portfolio-coin
     direction TB
 	Coins --> ID[(coin-identity)]
     Coins -.-> MF2[master-fingerprint]
@@ -547,13 +547,13 @@ account = 1
 token-ids = 2
 ```
 
-- **CDDL for synchronizing accounts with their coin identity** `crypto-portfolio-coin`
+- **CDDL for synchronizing accounts with their coin identity** `portfolio-coin`
 
-In this document, we are defining the new `crypto-portfolio-coin` UR type associating the `coin-identity` defined in [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md) with their accounts. The accounts are preferably defined using a list of `detailed-account`. 
+In this document, we are defining the new `portfolio-coin` UR type associating the `coin-identity` defined in [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md) with their accounts. The accounts are preferably defined using a list of `detailed-account`. 
 
 To keep full compatibility with the layer 2, the accounts can also be specified using `account` and `crypto-multi-account` UR types. Using these UR types will however limit the information which can be synchronized.
 
-The following specification of `crypto-portfolio-coin` is written in CDDL. When used embedded in another CBOR structure, this structure should be tagged #6.1403.
+The following specification of `portfolio-coin` is written in CDDL. When used embedded in another CBOR structure, this structure should be tagged #6.41403.
 
 ```
 ; Associate a coin identity to its accounts
@@ -613,8 +613,8 @@ When used embedded in another CBOR structure, this structure should be tagged #6
 ; Top level multi coin sync payload
 
 sync = {
-		coins: [+ #6.41402(crypto-portfolio-coin)],           ; Multiple coins with their respective accounts and coin identities
-		? metadata: #6.1403(crypto-portfolio-metadata) ; Optional wallet metadata
+		coins: [+ #6.41402(portfolio-coin)],           ; Multiple coins with their respective accounts and coin identities
+		? metadata: #6.41403(crypto-portfolio-metadata) ; Optional wallet metadata
 }
 
 coins = 1
@@ -985,7 +985,7 @@ An example illustrates how the sync payload is formed using the third layer of c
 
 ```
 {
- 1: [ 1403( ; #6.1403(crypto-portfolio-coin)
+ 1: [ 41403( ; #6.41403(portfolio-coin)
    {1: 41401( ; #6.41401(coin-identity)
         {1: 8, ; secp256k1 curve
          2: 60, ; Ethereum BIP44
@@ -1001,7 +1001,7 @@ An example illustrates how the sync payload is formed using the third layer of c
         2: [ h'A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' ]  ; USDC ERC20 token on Ethereum 
        })]
    }),
-   1403( ; #6.1403(crypto-portfolio-coin) 
+   41403( ; #6.41403(portfolio-coin) 
    {1: 41401( ; #6.41401(coin-identity)
         {1: 6, ; ed25519 curve
          2: 501 ; Solana BIP44
@@ -1020,7 +1020,7 @@ An example illustrates how the sync payload is formed using the third layer of c
           })
        })]
    }),
-   1403( ; #6.1403(crypto-portfolio-coin)
+   41403( ; #6.41403(portfolio-coin)
    {1: 41401( ; #6.41401(coin-identity)
         {1: 8, ; secp256k1 curve
          2: 60, ; Ethereum BIP44
@@ -1036,7 +1036,7 @@ An example illustrates how the sync payload is formed using the third layer of c
         2: [ h'2791Bca1f2de4661ED88A30C99A7a9449Aa84174' ] ; USDC ERC20 token on Polygon 
        })]
    }),
-   1403( ; #6.1403(crypto-portfolio-coin)
+   41403( ; #6.41403(portfolio-coin)
    {1: 41401( ; #6.41401(coin-identity)
         {1: 8, ; secp256k1 curve
          2: 0 ; Bitcoin BIP44
@@ -1066,7 +1066,7 @@ An example illustrates how the sync payload is formed using the third layer of c
 	   )]
     })
  ],
- 2: 1403( ; #6.1403(crypto-metadata)
+ 2: 1404( ; #6.1404(crypto-metadata)
    {1: 934670036, ; master-fingerprint
     2: "en", ; language
     3: "1.7-2.rc", ; version

--- a/papers/nbcr-2023-002-multi-layer-sync.md
+++ b/papers/nbcr-2023-002-multi-layer-sync.md
@@ -110,7 +110,7 @@ Finally we propose in this document a third layer based on the `crypto-portfolio
 | `coin-identity` | 41401 | Ngrave | Add additional information to a specific hdkey | [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md) |
 | `detailed-account` | 41402 | Ngrave | Import multiple accounts with and without output descriptors and specify optionally tokens to synchronize | This document |
 | `portfolio-coin` | 41403 | Ngrave | Associate several accounts to its coin identity  | This document |
-| `crypto-portfolio-metadata` | 1404 | Ngrave | Specify wallet metadata | This document |
+| `portfolio-metadata` | 41404 | Ngrave | Specify wallet metadata | This document |
 | `crypto-portfolio` | 1405 | Ngrave | Aggregate the portfolio information | This document |
 
 The table contains deprecated BlockchainCommons UR types that may still be used by some wallets, and therefore should be supported along with the new versions for backward compatibility. In the following document, we will however describe the sync protocol using the latest versions proposed by BlockchainCommons. 
@@ -453,7 +453,7 @@ device = 3
 
 The third layer of the proposed sync protocol is based on `crypto-portfolio` UR type, aiming to synchronize the accounts related to multiple coins.
 
-We break down its structure in Figure 5 based on newly defined UR types: `portfolio-coin`, `coin-identity`, `detailed-account` and `crypto-portfolio-metadata`. The CDDL for the new UR types are given hereafter.
+We break down its structure in Figure 5 based on newly defined UR types: `portfolio-coin`, `coin-identity`, `detailed-account` and `portfolio-metadata`. The CDDL for the new UR types are given hereafter.
 
 ```mermaid
 flowchart TB
@@ -462,11 +462,11 @@ flowchart TB
 	subgraph crypto-portfolio
     direction TB
 	Sync --> Coins[[portfolio-coin]]
-	Sync -.-> Meta[(crypto-portfolio-metadata)]
+	Sync -.-> Meta[(portfolio-metadata)]
     end
 
-	%% crypto-portfolio-metadata breakdown
-	subgraph crypto-portfolio-metadata
+	%% portfolio-metadata breakdown
+	subgraph portfolio-metadata
     direction TB
 	Meta -...-> sync_id
 	Meta -...-> language
@@ -574,13 +574,13 @@ coin-id = 1
 accounts = 2
 ```
 
-- **CDDL for syncing metadata** `crypto-portfolio-metadata`
+- **CDDL for syncing metadata** `portfolio-metadata`
 
-In this document, we are defining the new `crypto-portfolio-metadata` UR type to include device metadata related to the offline signer.
+In this document, we are defining the new `portfolio-metadata` UR type to include device metadata related to the offline signer.
 
 In many QR-based offline signer, the synchronization payload includes metadata information related to the device. We have created a general purpose UR type to include such information.
 
-When used embedded in another CBOR structure, this structure should be tagged #6.1404.
+When used embedded in another CBOR structure, this structure should be tagged #6.41404.
 
 ```
 metadata = {
@@ -613,8 +613,8 @@ When used embedded in another CBOR structure, this structure should be tagged #6
 ; Top level multi coin sync payload
 
 sync = {
-		coins: [+ #6.41402(portfolio-coin)],           ; Multiple coins with their respective accounts and coin identities
-		? metadata: #6.41403(crypto-portfolio-metadata) ; Optional wallet metadata
+		coins: [+ #6.41403(portfolio-coin)],           ; Multiple coins with their respective accounts and coin identities
+		? metadata: #6.441404(portfolio-metadata) ; Optional wallet metadata
 }
 
 coins = 1
@@ -939,7 +939,7 @@ The accounts of each coin are described using a list of `detailed-account` indic
 
 The accounts are always grouped under a coin identity with the `coin-identity` UR type.
 
-Additionally, the offline signer can send metadata in `crypto-portfolio-metadata` along with the coins and the accounts.
+Additionally, the offline signer can send metadata in `portfolio-metadata` along with the coins and the accounts.
 
 **Use case**
 
@@ -1066,7 +1066,7 @@ An example illustrates how the sync payload is formed using the third layer of c
 	   )]
     })
  ],
- 2: 1404( ; #6.1404(crypto-metadata)
+ 2: 41404( ; #6.41404(crypto-metadata)
    {1: 934670036, ; master-fingerprint
     2: "en", ; language
     3: "1.7-2.rc", ; version

--- a/papers/nbcr-2023-002-multi-layer-sync.md
+++ b/papers/nbcr-2023-002-multi-layer-sync.md
@@ -508,7 +508,7 @@ In this document, we are defining the new `detailed-account` UR type, extending 
 This new type aims to incorporate in the same structure:
 
 - The accounts with and without scripts by selecting either `hdkey` or `output-descriptor`. When a `hdkey` is embedded inside `detailed-account`, the optional `coin-info` in `hdkey` should **not** be defined since `detailed-account` is used in combination with `coin-identity` used already as asset identifier. 
-- An optional list of tokens to synchronize them at the same time of the associated account. A token identifier is defined as a string or tagged with #6.263 to specify a [[hexString]](https://github.com/toravir/CBOR-Tag-Specs/blob/master/hexString.md).
+- An optional list of tokens to synchronize them at the same time of the associated account. A token identifier is defined either as a string or as bytes.
 
 The following specification of `detailed-account` is written in CDDL. When used embedded in another CBOR structure, this structure should be tagged #6.41402.
 
@@ -521,9 +521,6 @@ account_exp = #6.40303(hdkey) / #6.40308(output-descriptor)
 ; extended public keys.
 ; '#6.308(output-descriptor)' should be used to share an output descriptor, 
 ; e.g. for the different Bitcoin address formats (P2PKH, P2SH-P2WPKH, P2WPKH, P2TR).
-
-hex_string = #6.263(bstr) ; byte string is a hexadecimal string no need for decoding
-token-id = string / hex_string
 
 ; Optional 'token-ids' to indicate the synchronization of a list of tokens with
 ; the associated accounts
@@ -540,7 +537,7 @@ token-id = string / hex_string
 
 detailed-account = { 
   account: account_exp,
-  ? token-ids: [+ token-id] ; Specify multiple tokens associated to one account
+  ? token-ids: [+ string / bytes] ; Specify multiple tokens associated to one account
 }
 
 account = 1
@@ -1382,4 +1379,3 @@ The information shared with the watch-only wallet can be altered on the device r
 | [NBCR-2023-001] | https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md |
 | [BIP32] | https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki |
 | [SLIP44]  | https://github.com/satoshilabs/slips/blob/master/slip-0044.md |
-| [hexString] | https://github.com/toravir/CBOR-Tag-Specs/blob/master/hexString.md |

--- a/papers/nbcr-2023-002-multi-layer-sync.md
+++ b/papers/nbcr-2023-002-multi-layer-sync.md
@@ -89,7 +89,7 @@ The second layer is based on two UR types:
 1) `account` (#6.40311) proposed by BC in [[BCR-2023-019]](https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2023-019-account-descriptor.md) to share a list of output descriptors associated to an xpub key (mostly useful to sync with Bitcoin-only wallets). A previous version `crypto-account` (#6.311) defined in [[BCR-2020-015]](https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-015-account.md) is deprecated, but may still be supported for backwards compatibility.
 2) `multi-account` (#6.41103), replacing `crypto-multi-account` (#6.1103) introduced by Keystone in [[solana-qr-data-protocol]](https://github.com/KeystoneHQ/Keystone-developer-hub/blob/main/research/solana-qr-data-protocol.md#setup-watch-only-wallet-by-offline-signer) to share multiple public keys with the watch-only wallet (e.g. with coins based on ed25519 curves where each account contains a fully hardened derivation path). The version defined in [[solana-qr-data-protocol]](https://github.com/KeystoneHQ/Keystone-developer-hub/blob/main/research/solana-qr-data-protocol.md#setup-watch-only-wallet-by-offline-signer)  still uses deprecated BCR versions with `crypto-hdkey` (#6.303). We propose in this document the updated version, even if the legacy version may still be supported for backwards compatibility. 
 
-Finally we propose in this document a third layer based on the `crypto-portfolio` UR type extended the two other layers to add extra information: 1) by defining a coin identity to specify the elliptic curve and any subtype (e.g. chain ID for EVM chains), 2) by adding token IDs and 3) by sending device-related metadata in the sync payload.
+Finally we propose in this document a third layer based on the `portfolio` UR type extended the two other layers to add extra information: 1) by defining a coin identity to specify the elliptic curve and any subtype (e.g. chain ID for EVM chains), 2) by adding token IDs and 3) by sending device-related metadata in the sync payload.
 
 ## Sync UR types registry
 
@@ -111,7 +111,7 @@ Finally we propose in this document a third layer based on the `crypto-portfolio
 | `detailed-account` | 41402 | Ngrave | Import multiple accounts with and without output descriptors and specify optionally tokens to synchronize | This document |
 | `portfolio-coin` | 41403 | Ngrave | Associate several accounts to its coin identity  | This document |
 | `portfolio-metadata` | 41404 | Ngrave | Specify wallet metadata | This document |
-| `crypto-portfolio` | 1405 | Ngrave | Aggregate the portfolio information | This document |
+| `portfolio` | 41405 | Ngrave | Aggregate the portfolio information | This document |
 
 The table contains deprecated BlockchainCommons UR types that may still be used by some wallets, and therefore should be supported along with the new versions for backward compatibility. In the following document, we will however describe the sync protocol using the latest versions proposed by BlockchainCommons. 
 
@@ -451,15 +451,15 @@ device = 3
 
 ### UR registry constituting the layer 3
 
-The third layer of the proposed sync protocol is based on `crypto-portfolio` UR type, aiming to synchronize the accounts related to multiple coins.
+The third layer of the proposed sync protocol is based on `portfolio` UR type, aiming to synchronize the accounts related to multiple coins.
 
 We break down its structure in Figure 5 based on newly defined UR types: `portfolio-coin`, `coin-identity`, `detailed-account` and `portfolio-metadata`. The CDDL for the new UR types are given hereafter.
 
 ```mermaid
 flowchart TB
 	%% crypto-sync breakdown
-	Sync[(crypto-portfolio)]
-	subgraph crypto-portfolio
+	Sync[(portfolio)]
+	subgraph portfolio
     direction TB
 	Sync --> Coins[[portfolio-coin]]
 	Sync -.-> Meta[(portfolio-metadata)]
@@ -499,7 +499,7 @@ flowchart TB
 	ID -..-> Subtypes[(subtype)]
 	end
 ```
-Figure 5. Breakdown of crypto-portfolio forming the layer 3 of the sync protocol
+Figure 5. Breakdown of portfolio forming the layer 3 of the sync protocol
 
 - **CDDL for synchronizing several accounts with detailed information** `detailed-account`
 
@@ -603,11 +603,11 @@ language_code = string ; following [ISO 639-1] Code (e.g. "en" for English,
 
 The language is encoded with alpha-2 code to represent the names of the language following [[ISO 639-1]](https://www.iso.org/standard/22109.html).
 
-- **CDDL for syncing the general purpose payload** `crypto-portfolio`
+- **CDDL for syncing the general purpose payload** `portfolio`
 
-In this document, we are defining the new UR type `crypto-portfolio` to aggregate accounts, coin identity and metadata information together.
+In this document, we are defining the new UR type `portfolio` to aggregate accounts, coin identity and metadata information together.
 
-When used embedded in another CBOR structure, this structure should be tagged #6.1405.
+When used embedded in another CBOR structure, this structure should be tagged #6.41405.
 
 ```
 ; Top level multi coin sync payload
@@ -632,7 +632,7 @@ The online watch-only wallet has different needs regarding the information neede
    a. The accounts are defined with different output descriptors using `account` UR type (e.g. syncing Bitcoin accounts with BTC-only watch-only wallet).     
    b. The accounts of the same coin are defined by several public keys and different derivation paths using `crypto-multi-accounts` UR type (e.g. syncing Solana accounts with Solflare wallet as watch-only wallet). 
 
-3) Sync the accounts of multiple coins identified with their coin identity, along with optional tokens information and device-related metadata, using `crypto-portfolio` UR type (e.g. syncing any coin and token between NGRAVE ZERO offline signer and NGRAVE LIQUID watch-only wallet).
+3) Sync the accounts of multiple coins identified with their coin identity, along with optional tokens information and device-related metadata, using `portfolio` UR type (e.g. syncing any coin and token between NGRAVE ZERO offline signer and NGRAVE LIQUID watch-only wallet).
 
 ### 1) Sync a single coin based on a unique extended public key (Metamask case)
 
@@ -933,7 +933,7 @@ ur:crypto-multi-accounts/hgadfwnehnntlgaofelegtcdhdatbkhkaofmspcthepyjnrkdtmhasb
 
 ### 3) Sync multiple coins with their coin identifier (NGRAVE case)
 
-Compared to the first and second layers of the sync protocol, the third layer is made for every watch-only wallets aiming to support any coins, representing the generic case how NGRAVE ZERO offline signer and NGRAVE LIQUID app are functioning. The `crypto-portfolio` UR type includes multiple coins/blockchains based on different elliptic curves. 
+Compared to the first and second layers of the sync protocol, the third layer is made for every watch-only wallets aiming to support any coins, representing the generic case how NGRAVE ZERO offline signer and NGRAVE LIQUID app are functioning. The `portfolio` UR type includes multiple coins/blockchains based on different elliptic curves. 
 
 The accounts of each coin are described using a list of `detailed-account` indicating a public key or extended public key, a derivation path, a potential script type and a potential list of tokens associated to the account.
 
@@ -1048,8 +1048,7 @@ An example illustrates how the sync payload is formed using the third layer of c
                40303({ ; hdkey
                   3: h'03EB3E2863911826374DE86C231A4B76F0B89DFA174AFB78D7F478199884D9DD32', ; key-data
                   4: h'6456A5DF2DB0F6D9AF72B2A1AF4B25F45200ED6FCC29C3440B311D4796B70B5B', ; chain-code
-                  6: 40304({1: [44, true, 0, true, 0, true]}), ; origin 44'/0'/0'
-                  8: 2583285239 ; parent fingerprint
+                  6: 40304({1: [44, true, 0, true, 0, true]}) ; origin 44'/0'/0'
             })]	 
 	     })}),
          41402( ; #6.441402(detailed-account)
@@ -1059,8 +1058,7 @@ An example illustrates how the sync payload is formed using the third layer of c
                40303({ ; hdkey
                   3: h'02C7E4823730F6EE2CF864E2C352060A88E60B51A84E89E4C8C75EC22590AD6B69', ; key-data
                   4: h'9D2F86043276F9251A4A4F577166A5ABEB16B6EC61E226B5B8FA11038BFDA42D', ; chain-code
-                  6: 40304({1: [49, true, 0, true, 1, true]}), ; origin 49'/0'/1'
-                  8: 2819587291 ; parent fingerprint
+                  6: 40304({1: [49, true, 0, true, 1, true]}) ; origin 49'/0'/1'
             })]  
           })}
 	   )]
@@ -1081,10 +1079,10 @@ An example illustrates how the sync payload is formed using the third layer of c
 A2                                      # map(2)
    01                                   # unsigned(1)
    84                                   # array(4)
-      D9 057B                           # tag(1403)
+      D9 A1BB                           # tag(41403)
          A2                             # map(2)
             01                          # unsigned(1)
-            D9 0579                     # tag(1401)
+            D9 A1B9                     # tag(41401)
                A3                       # map(3)
                   01                    # unsigned(1)
                   08                    # unsigned(8)
@@ -1095,7 +1093,7 @@ A2                                      # map(2)
                      01                 # unsigned(1)
             02                          # unsigned(2)
             81                          # array(1)
-               D9 057A                  # tag(1402)
+               D9 A1BA                  # tag(41402)
                   A2                    # map(2)
                      01                 # unsigned(1)
                      D9 9D6F            # tag(40303)
@@ -1132,10 +1130,10 @@ A2                                      # map(2)
                      81                 # array(1)
                         54              # bytes(20)
                            A0B86991C6218B36C1D19D4A2E9EB0CE3606EB48 
-      D9 057B                           # tag(1403)
+      D9 A1BB                           # tag(41403)
          A2                             # map(2)
             01                          # unsigned(1)
-            D9 0579                     # tag(1401)
+            D9 A1B9                     # tag(41401)
                A2                       # map(2)
                   01                    # unsigned(1)
                   06                    # unsigned(6)
@@ -1143,7 +1141,7 @@ A2                                      # map(2)
                   19 01F5               # unsigned(501)
             02                          # unsigned(2)
             82                          # array(2)
-               D9 057A                  # tag(1402)
+               D9 A1BA                  # tag(41402)
                   A2                    # map(2)
                      01                 # unsigned(1)
                      D9 9D6F            # tag(40303)
@@ -1168,7 +1166,7 @@ A2                                      # map(2)
                      81                 # array(1)
                         78 2C           # text(44)
                            45506A465764643541756671535371654D32714E31787A7962617043384734774547476B5A77795444743176 # "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-               D9 057A                  # tag(1402)
+               D9 A1BA                  # tag(41402)
                   A1                    # map(1)
                      01                 # unsigned(1)
                      D9 9D6F            # tag(40303)
@@ -1189,10 +1187,10 @@ A2                                      # map(2)
                                     F5  # primitive(21)
                                     01  # unsigned(1)
                                     F5  # primitive(21)
-      D9 057B                           # tag(1403)
+      D9 A1BB                           # tag(41403)
          A2                             # map(2)
             01                          # unsigned(1)
-            D9 0579                     # tag(1401)
+            D9 A1B9                     # tag(41401)
                A3                       # map(3)
                   01                    # unsigned(1)
                   08                    # unsigned(8)
@@ -1203,7 +1201,7 @@ A2                                      # map(2)
                      18 89              # unsigned(137)
             02                          # unsigned(2)
             81                          # array(1)
-               D9 057A                  # tag(1402)
+               D9 A1BA                  # tag(41402)
                   A2                    # map(2)
                      01                 # unsigned(1)
                      D9 9D6F            # tag(40303)
@@ -1240,10 +1238,10 @@ A2                                      # map(2)
                      81                 # array(1)
                         54              # bytes(20)
                            2791BCA1F2DE4661ED88A30C99A7A9449AA84174 
-      D9 057B                           # tag(1403)
+      D9 A1BB                           # tag(41403)
          A2                             # map(2)
             01                          # unsigned(1)
-            D9 0579                     # tag(1401)
+            D9 A1B9                     # tag(41401)
                A2                       # map(2)
                   01                    # unsigned(1)
                   08                    # unsigned(8)
@@ -1251,7 +1249,7 @@ A2                                      # map(2)
                   00                    # unsigned(0)
             02                          # unsigned(2)
             82                          # array(2)
-               D9 057A                  # tag(1402)
+               D9 A1BA                  # tag(41402)
                   A1                    # map(1)
                      01                 # unsigned(1)
                      D9 9D74            # tag(40308)
@@ -1262,7 +1260,7 @@ A2                                      # map(2)
                            02           # unsigned(2)
                            81           # array(1)
                               D9 9D6F   # tag(40303)
-                                 A4     # map(4)
+                                 A3     # map(3)
                                     03  # unsigned(3)
                                     58 21 # bytes(33)
                                        03EB3E2863911826374DE86C231A4B76F0B89DFA174AFB78D7F478199884D9DD32 
@@ -1280,9 +1278,7 @@ A2                                      # map(2)
                                              F5 # primitive(21)
                                              00 # unsigned(0)
                                              F5 # primitive(21)
-                                    08  # unsigned(8)
-                                    1A 99F9CDF7 # unsigned(2583285239)
-               D9 057A                  # tag(1402)
+               D9 A1BA                  # tag(41402)
                   A1                    # map(1)
                      01                 # unsigned(1)
                      D9 9D74            # tag(40308)
@@ -1293,7 +1289,7 @@ A2                                      # map(2)
                            02           # unsigned(2)
                            81           # array(1)
                               D9 9D6F   # tag(40303)
-                                 A4     # map(4)
+                                 A3     # map(3)
                                     03  # unsigned(3)
                                     58 21 # bytes(33)
                                        02C7E4823730F6EE2CF864E2C352060A88E60B51A84E89E4C8C75EC22590AD6B69 
@@ -1311,10 +1307,8 @@ A2                                      # map(2)
                                              F5 # primitive(21)
                                              01 # unsigned(1)
                                              F5 # primitive(21)
-                                    08  # unsigned(8)
-                                    1A A80F7CDB # unsigned(2819587291)
    02                                   # unsigned(2)
-   D9 057B                              # tag(1403)
+   D9 A1BC                              # tag(41404)
       A4                                # map(4)
          01                             # unsigned(1)
          1A 37B5EED4                    # unsigned(934670036)
@@ -1332,7 +1326,7 @@ A2                                      # map(2)
 - UR encoding 
 
 ```
-ur:crypto-portfolio/hdadftlebeenhdadlebedwhgadbraoetpsatenadaoenlebedthdadlegtcdhdatbkhkathtatlemkhdpybefkonrkteahetfrrkhlfgftbkftrelnmwlfdmehfmleengdptlgasbkhtctgdhlltmkhljplffgphutfwldhdflimcptemwhlbdaeenfplggnorcwkeiagpbdbdlegtckhladfdetkkpketpspkaepkbklegtckhladftaeprfeaeadpraoenzogwiacefdlahkfmnslelngtsnkegdhdltnsbdnksplebeenhdadlebedwhdadbdaoftadpkaofelebedthdadlegtcdhdatbkhkaonrmeiadthlcebemwiactphfhlypkglctbekgkkmecesdiamhnspelgzofltnhtenbdleadlyhladfeetkkpkftadpkpkaepkaepkaoendnkksetgchsdadbsbsmhrsdnbnctwfwfctbmtelpcttnlndndtdwbkbeckrlolspmwdrsespspcpbkdrdwzorecelndtlebedthladlegtcdhdatbkhkaobdahqznlcfieftsdhkhdcpcebkbbhtcwhepedtltrlgtaonenldnaonkknpshgsdbdlegtckhladfeetkkpkftadpkpkaepkadpklebeenhdadlebedwhgadbraoetpsatenetfdaoenlebedthdadlegtcdhdatbkhkathtatlemkhdpybefkonrkteahetfrrkhlfgftbkftrelnmwlfdmehfmleengdptlgasbkhtctgdhlltmkhljplffgphutfwldhdflimcptemwhlbdaeenfplggnorcwkeiagpbdbdlegtckhladfdetkkpketpspkaepkbklegtckhladftaeprfeaeaopraoenzoinfdjthlormksdbensfehgcfgphehrregthlrscelebeenhdadlebedwhdadbraoaeaofelebedthladlegtcehdadcdckcpctimrklyjeaoenlegtcdhdatbkhkatnkqzimbtfdetienetenlcmhefwsydtoniagtpkehsnpednleprdnftgnftlemelpasbkhtbsahhmmdkghdptlehtcbhyhlhtsyhtprvtaenscdlejeldrebblngespfehebbbnbdlegtckhladfdetkkpkaepkaepkbrfwgppklkpslebedthladlegtcehdadcmcwctimdrckcpctimrklyjejeaoenlegtcdhdatbkhkaolfmefenelyptntkkphbsmtldvtbdbpfemhbbuthltnfdmelnlfbwlyhtfdhecpceasbkhtgtldfdaslpdtpkhtfwsntpadctbnhmhpnkdmhtndbemtiehniapkcnatfmpehdkgbdlegtckhladfdetlnpkaepkadpkbrfwhlcbeymeaolebeenhdadfwnehnntlgaobkbmctatctlnkenekglpkecbbtasbntnspvtrsahse
+ur:portfolio/hdadftlehljphdadlehljnhgadbraoetpsatenadaoenlehljehdadlegtcdhdatbkhkathtatlemkhdpybefkonrkteahetfrrkhlfgftbkftrelnmwlfdmehfmleengdptlgasbkhtctgdhlltmkhljplffgphutfwldhdflimcptemwhlbdaeenfplggnorcwkeiagpbdbdlegtckhladfdetkkpketpspkaepkbklegtckhladftaeprfeaeadpraoenzogwiacefdlahkfmnslelngtsnkegdhdltnsbdnksplehljphdadlehljnhdadbdaoftadpkaofelehljehdadlegtcdhdatbkhkaonrmeiadthlcebemwiactphfhlypkglctbekgkkmecesdiamhnspelgzofltnhtenbdleadlyhladfeetkkpkftadpkpkaepkaepkaoendnkksetgchsdadbsbsmhrsdnbnctwfwfctbmtelpcttnlndndtdwbkbeckrlolspmwdrsespspcpbkdrdwzorecelndtlehljehladlegtcdhdatbkhkaobdahqznlcfieftsdhkhdcpcebkbbhtcwhepedtltrlgtaonenldnaonkknpshgsdbdlegtckhladfeetkkpkftadpkpkaepkadpklehljphdadlehljnhgadbraoetpsatenetfdaoenlehljehdadlegtcdhdatbkhkathtatlemkhdpybefkonrkteahetfrrkhlfgftbkftrelnmwlfdmehfmleengdptlgasbkhtctgdhlltmkhljplffgphutfwldhdflimcptemwhlbdaeenfplggnorcwkeiagpbdbdlegtckhladfdetkkpketpspkaepkbklegtckhladftaeprfeaeaopraoenzoinfdjthlormksdbensfehgcfgphehrregthlrscelehljphdadlehljnhdadbraoaeaofelehljehladlegtcehdadcdckcpctimrklyjeaoenlegtcdhgatbkhkatnkqzimbtfdetienetenlcmhefwsydtoniagtpkehsnpednleprdnftgnftlemelpasbkhtbsahhmmdkghdptlehtcbhyhlhtsyhtprvtaenscdlejeldrebblngespfehebbbnbdlegtckhladfdetkkpkaepkaepklehljehladlegtcehdadcmcwctimdrckcpctimrklyjejeaoenlegtcdhgatbkhkaolfmefenelyptntkkphbsmtldvtbdbpfemhbbuthltnfdmelnlfbwlyhtfdhecpceasbkhtgtldfdaslpdtpkhtfwsntpadctbnhmhpnkdmhtndbemtiehniapkcnatfmpehdkgbdlegtckhladfdetlnpkaepkadpkaolehljthdadfwnehnntlgaobkbmctatctlnkenekglpkecbbtasbntnspvtrsahse
 ```
 
 </details>

--- a/papers/nbcr-2023-003-crypto-sign.md
+++ b/papers/nbcr-2023-003-crypto-sign.md
@@ -77,7 +77,7 @@ The user can initiate the signing protocol on a watch-only wallet synchronized w
 
 The existing communication protocol for signing are based on UR types specific to each blockchain. Except for Bitcoin with `psbt` UR type, the signing request prepared by the watch-only wallet is embedded in a UR type with the extension `sign-request`. Once the transaction is signed, the offline signer sends the signature back to the watch-only wallet by encoding the data in a UR type with the extension `signature`.
 
-This document proposes to standardize into one UR type `crypto-sign-request` for the signing request and another UR type `crypto-signature` for the signed message.
+This document proposes to standardize into one UR type `sign-request` for the signing request and another UR type `crypto-signature` for the signed message.
 
 The following table listed the existing UR types depending on the blockchain and introduced the new UR types intended to be blockchain agnostic.
 
@@ -88,7 +88,7 @@ The following table listed the existing UR types depending on the blockchain and
 | Ethereum/EVM | eth-sign-request <br> Tag: 401 | eth-signature <br> Tag: 402 | Keystone | [[EIP-4527]](https://eips.ethereum.org/EIPS/eip-4527) | [[ur-registry-eth]](https://github.com/KeystoneHQ/keystone-airgaped-base/tree/master/packages/ur-registry-eth) |
 | Solana| sol-sign-request <br> Tag: 1101 | sol-signature <br> Tag: 1102 | Keystone | [[solana-qr-data-protocol]](https://github.com/KeystoneHQ/Keystone-developer-hub/blob/main/research/solana-qr-data-protocol.md#sending-the-unsigned-data-from-wallet-only-wallet-to-offline-signer)  | [[ur-registry-sol]](https://github.com/KeystoneHQ/keystone-airgaped-base/tree/master/packages/ur-registry-sol) |
 | Tezos | xtz-sign-request <br> Tag: 501 | xtz-signature <br> Tag: 502 | Airgap  | [[tzip-25]](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-25/tzip-25.md) | [[ur-registry-xtz]](https://socket.dev/npm/package/@airgap/ur-registry-xtz/overview/0.0.1-beta.0) |
-| Generic | crypto-sign-request <br> Tag: 1411 | crypto-signature <br> Tag: 1412 | Ngrave | This document | [[ur-registry]](https://github.com/ngraveio/ur-registry/tree/main) |
+| Generic | sign-request <br> Tag: 41411 | crypto-signature <br> Tag: 1412 | Ngrave | This document | [[ur-registry]](https://github.com/ngraveio/ur-registry/tree/main) |
 
 The specification for each UR type contains CBOR structure, expressed thereafter in Concise Data Definition Language [[CDDL]](https://datatracker.ietf.org/doc/html/rfc8610).
 
@@ -239,7 +239,7 @@ For Tezos blockchain, the UR types are based on the [[TZIP-25]](https://gitlab.c
 
 - **CDDL for XTZ signature request** `xtz-sign-request`
 
-This UR type belongs to the [[TZIP-25]](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-25/tzip-25.md) proposal and is tagged with #6.1411. 
+This UR type belongs to the [[TZIP-25]](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-25/tzip-25.md) proposal and is tagged with #6.41411. 
 
 Two different CDDL expressions have been proposed regarding how to specify the signer account. The [[TZIP-25]](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-25/tzip-25.md) proposal opted for specifying the signer account through the derivation path, while the implementation [[ur-registry-xtz]](https://socket.dev/npm/package/@airgap/ur-registry-xtz/overview/0.0.1-beta.0) proposed to specify only the associated public key. 
 
@@ -305,9 +305,9 @@ payload = 3
 
 This document aims to propose common UR types for signing on every blockchain. 
 
-- **CDDL for generic signature request** `crypto-sign-request`
+- **CDDL for generic signature request** `sign-request`
 
-This UR type is tagged with #6.1411 and embeds:
+This UR type is tagged with #6.41411 and embeds:
 
 - The `coin-identity` UR type tagged with #6.140 and introduced in [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md). This UR type identifies the elliptic curve and the blockchain on which the sign request is initiated.
 - An optional UR type to specify metadata related to a specific coin.
@@ -317,7 +317,7 @@ This UR type is tagged with #6.1411 and embeds:
 ; The list is not exhaustive and includes only the metadata for ETH, SOL and XTZ
 coin-meta = #6.1420(eth-meta) / #6.1421(sol-meta) / #6.1422(xtz-meta) 
 
-crypto-sign-request = {
+sign-request = {
     ?request-id: uuid,                        ; Identifier of the signing request
     coin-id: #6.441401(coin-identity),   ; Provides information on the elliptic curve and the blockchain/coin
     ?derivation-path: #6.40304(keypath),      ; Key path for signing this request
@@ -334,13 +334,13 @@ origin = 5
 metadata = 6
 ```
 
-We are listing thereafter the metadata UR types for the blockchains listed in this document. This list is not exhaustive and needs to be updated for each coin needing additional data to the `crypto-sign-request` UR type.
+We are listing thereafter the metadata UR types for the blockchains listed in this document. This list is not exhaustive and needs to be updated for each coin needing additional data to the `sign-request` UR type.
 
 | Blockchain | Metadata required | coin-meta UR type |
 | --- | --- | --- |
 | Ethereum/EVM chains | Yes | - CDDL description: <br> `eth-meta = { data-type: sign-data-type, ?address: eth-address-bytes}` <br> `sign-data-type` and `eth-address-bytes` definition are inherited from eth-sign-request. <br> - Tag: 1420 |
-| Solana | No | - CDDL description: <br> `sol-meta = { ?type: int .default sign-type-transaction, ?address: bytes}`  <br> `type` definition is inherited from sol-sign-request. The default value `sign-type-transaction` should be used in case of missing metadata in crypto-sign-request for a Solana transaction. <br> - Tag: 1421 |
-| Tezos | No | - CDDL description: <br> `xtz-meta = { ?data-type: int .default data-type-operation}` <br> `data-type definition` is inherited from xtz-sign-request. <br> The default value of data-type should be used in case of missing metadata in crypto-sign-request for Tezos transaction. <br> - Tag: 1422 |
+| Solana | No | - CDDL description: <br> `sol-meta = { ?type: int .default sign-type-transaction, ?address: bytes}`  <br> `type` definition is inherited from sol-sign-request. The default value `sign-type-transaction` should be used in case of missing metadata in sign-request for a Solana transaction. <br> - Tag: 1421 |
+| Tezos | No | - CDDL description: <br> `xtz-meta = { ?data-type: int .default data-type-operation}` <br> `data-type definition` is inherited from xtz-sign-request. <br> The default value of data-type should be used in case of missing metadata in sign-request for Tezos transaction. <br> - Tag: 1422 |
 | Bitcoin <br> MultiversX <br> Stellar | No | No metadata needed |
 
 - **CDDL for generic signature response** `crypto-signature`
@@ -354,7 +354,7 @@ crypto-signature = {
   ?origin: text,         ; The device info providing this signature
 }
 
-; request-id must be present in case of response to a crypto-sign-request where 
+; request-id must be present in case of response to a sign-request where 
 ; the request-id is specified
 
 request-id = 1
@@ -370,7 +370,7 @@ This Section gives more details on the use case for each blockchain, the signing
 
 ## III - 1. Bitcoin transactions
 
-Since Bitcoin transactions follow [[BIP174]](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki) defining PSBT, the privileged UR type for signing is `psbt`. In this document, we present its integration into the common UR types `crypto-sign-request` and `crypto-signature`.
+Since Bitcoin transactions follow [[BIP174]](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki) defining PSBT, the privileged UR type for signing is `psbt`. In this document, we present its integration into the common UR types `sign-request` and `crypto-signature`.
 
 ### Integration with the generic UR types registry
 
@@ -378,11 +378,11 @@ Since Bitcoin transactions follow [[BIP174]](https://github.com/bitcoin/bips/blo
 
 A Bitcoin transaction is uniquely identified thanks to the information shared in `coin-identity` UR type, i.e. secp256k1 as elliptic curve and 0 as coin type. 
 
-The only other required field for requesting the signature of a Bitcoin transaction is the bytes composing the unsigned PSBT transaction, corresponding to the `sign-data` field of `crypto-sign-request` UR type.
+The only other required field for requesting the signature of a Bitcoin transaction is the bytes composing the unsigned PSBT transaction, corresponding to the `sign-data` field of `sign-request` UR type.
 
-The following table indicates the corresponding fields between the UR types `psbt` and `crypto-sign-request`.
+The following table indicates the corresponding fields between the UR types `psbt` and `sign-request`.
 
-| crypto-sign-request fields <br> Associated number corresponds to the order in UR type | Corresponding crypto-psbt fields <br> Associated number corresponds to the order in UR type |
+| sign-request fields <br> Associated number corresponds to the order in UR type | Corresponding crypto-psbt fields <br> Associated number corresponds to the order in UR type |
 | --- | --- |
 | 1. request-id (optional) | No corresponding field, adds verification step  |
 | 2. coin-id | No corresponding field, serves as identifier for BTC transactions |
@@ -390,7 +390,7 @@ The following table indicates the corresponding fields between the UR types `psb
 | 4. sign-data | 1. bytes |
 | 5. origin (optional) | No corresponding field, provides an additional description |
 
-`crypto-sign-request` UR type has the advantage to provide additional fields compared to `psbt` when used as a signing request: 
+`sign-request` UR type has the advantage to provide additional fields compared to `psbt` when used as a signing request: 
 - an unique identifier for the request to link the generated signature to the sign request, 
 - the derivation path of the account required to sign (not mandatory but important to identify the account(s) signing the psbt), 
 - the master fingerprint to identify the wallet,
@@ -424,8 +424,8 @@ A typical use case follows the following process between a watch-only wallet and
 - The watch-only adds then information to the PSBT that it has access to, following the Updater role in [[BIP174]](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki):
     1. If the Updater has the UTXO for an input, it should add it to the PSBT. 
     2. The Updater should also add redeemScripts, witnessScripts, and BIP 32 derivation paths to the input and output data if it knows them.
-- The watch-only wallet generates a QR code containing the `crypto-sign-request` UR type with the unsigned transaction and BTC as coin identity. Additionally, some recommended information is provided to the offline signer for verification purposes: request identifier, derivation path of the signer account, master fingerprint of the master public key and the watch-only wallet name.
-- The offline signer accepts the transmitted PSBT in `crypto-sign-request` UR type and provides the signature, following the Signer role in [[BIP174]](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki):
+- The watch-only wallet generates a QR code containing the `sign-request` UR type with the unsigned transaction and BTC as coin identity. Additionally, some recommended information is provided to the offline signer for verification purposes: request identifier, derivation path of the signer account, master fingerprint of the master public key and the watch-only wallet name.
+- The offline signer accepts the transmitted PSBT in `sign-request` UR type and provides the signature, following the Signer role in [[BIP174]](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki):
     1. The Signer must only use the UTXOs provided in the PSBT to produce signatures for inputs.
     2. Before signing a non-witness input, the Signer must verify that the TXID of the non-witness UTXO matches the TXID specified in the unsigned transaction. 
     3. Before signing a witness input, the Signer must verify that the witnessScript (if provided) matches the hash specified in the UTXO or the redeemScript, and the redeemScript (if provided) matches the hash in the UTXO. 
@@ -509,7 +509,7 @@ A5                                      # map(5)
 - UR encoding 
 
 ```
-ur:crypto-sign-request/hmadlkhttgpyzoddnebwptsebbfpmkhtfljtknrnhnaolehljnhdadbraoaeatlegtckhdadfeetkkpkaepkaepkaepraepraofwnehnntlgasbkheckcwbkcepyadaegtaoaeaeaeaobknldthkhncyhtcfhekkftckcksecmmecdeyjehmlndndwhepksefeenhyhpmednaeaeaeaeaepypypypyfmfgasinldndbmbpcthtsdjpbbbtfenrrehekecthyltdnmhjybkdwbeldeynrgeadaeaeaeaepypypypyaockhtonbraeaeaeaedmaeddlkblknctldbdbbbtldfechnkenbwtggpgemlcxteaemkpkbeaeaeaeaedmaeddaehlhrhdmeonphdthmfemdzmsdnlcekggeflaefpaeaeaeaeaeaeaeaeaebecytnspvtrsahsehtspsoutzmsore
+ur:sign-request/hmadlkhttgpyzoddnebwptsebbfpmkhtfljtknrnhnaolehljnhdadbraoaeatlegtckhdadfeetkkpkaepkaepkaepraepraofwnehnntlgasbkheckcwbkcepyadaegtaoaeaeaeaobknldthkhncyhtcfhekkftckcksecmmecdeyjehmlndndwhepksefeenhyhpmednaeaeaeaeaepypypypyfmfgasinldndbmbpcthtsdjpbbbtfenrrehekecthyltdnmhjybkdwbeldeynrgeadaeaeaeaepypypypyaockhtonbraeaeaeaedmaeddlkblknctldbdbbbtldfechnkenbwtggpgemlcxteaemkpkbeaeaeaeaedmaeddaehlhrhdmeonphdthmfemdzmsdnlcekggeflaefpaeaeaeaeaeaeaeaeaebecytnspvtrsahsehtspsoutzmsore
 ```
 
 </details>
@@ -567,7 +567,7 @@ The received PSBT should be decoded by the offline signer to know each input and
 
 ## II - 2. Ethereum transactions
 
-[[EIP-4527]](https://eips.ethereum.org/EIPS/eip-4527) proposes the specific UR types `eth-sign-request` and `eth-signature` for signing Ethereum transactions and in the same way transactions on every EVM blockchains. In this document, we present their integration into the common UR types `crypto-sign-request` and `crypto-signature`.
+[[EIP-4527]](https://eips.ethereum.org/EIPS/eip-4527) proposes the specific UR types `eth-sign-request` and `eth-signature` for signing Ethereum transactions and in the same way transactions on every EVM blockchains. In this document, we present their integration into the common UR types `sign-request` and `crypto-signature`.
 
 ### Integration with the generic UR types registry
 
@@ -587,9 +587,9 @@ Additionally, the following fields are recommended to be supplied by the watch-o
 - Unique request identifier
 - Origin of the sign request
 
-The following table indicates the corresponding fields between the UR types `eth-sign-request` and `crypto-sign-request`.
+The following table indicates the corresponding fields between the UR types `eth-sign-request` and `sign-request`.
 
-| crypto-sign-request fields <br> Associated number corresponds to the order in UR type | Corresponding eth-sign-request fields <br> Associated number corresponds to the order in UR type |
+| sign-request fields <br> Associated number corresponds to the order in UR type | Corresponding eth-sign-request fields <br> Associated number corresponds to the order in UR type |
 | --- | --- |
 | 1. request-id (optional) | 1. request-id (optional) |
 | 2. coin-id specifying the chain ID for EVM blockchains | 4. chain-id  |
@@ -599,7 +599,7 @@ The following table indicates the corresponding fields between the UR types `eth
 | 6.1. eth-meta.data-type | 3. data-type |
 | 6.2. eth-meta.address (optional) | 6. address (optional, completing the provided derivation path for account identification) |
 
-`crypto-sign-request` UR type provides the exact same information as `eth-sign-request`, with the advantage of `crypto-sign-request` to be blockchain-agnostic.
+`sign-request` UR type provides the exact same information as `eth-sign-request`, with the advantage of `sign-request` to be blockchain-agnostic.
 
 - **Ethereum signature**
 
@@ -619,7 +619,7 @@ The following table indicates the corresponding fields between the UR types `eth
 
 ### Use case
 
-The watch-only wallet generates a QR code containing the `crypto-sign-request` UR type with the following information:
+The watch-only wallet generates a QR code containing the `sign-request` UR type with the following information:
 
 1. (Recommended) Request ID, an universally unique identifier (UUID) of the transaction
 2. Ethereum coin identity with the chain ID to specify the EVM chain
@@ -717,7 +717,7 @@ A6                                      # map(6)
 - UR encoding 
 
 ```
-ur:crypto-sign-request/headlkhttgglgenktepyeosyheglmekncyenptlecyaolebedwhgadbraoetpsatetfdatlegtckhdadfeetkkpketpspkaepkaepraepraofwnehnntlgasbksyphsoecfdbtettncbgwaefeinclfkaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeechdeycebmcwcelpaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaebdaeadecececbecytnspvtrsahsehtspsoutzmsorebdlebefhhdadadaozogwpnlebehdphbphgtepyfdethnbshetebefkbkfd
+ur:sign-request/headlkhttgglgenktepyeosyheglmekncyenptlecyaolebedwhgadbraoetpsatetfdatlegtckhdadfeetkkpketpspkaepkaepraepraofwnehnntlgasbksyphsoecfdbtettncbgwaefeinclfkaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeechdeycebmcwcelpaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaebdaeadecececbecytnspvtrsahsehtspsoutzmsorebdlebefhhdadadaozogwpnlebehdphbphgtepyfdethnbshetebefkbkfd
 ```
 
 </details>
@@ -782,7 +782,7 @@ In case of more complex transactions, the offline signer should be able to recog
 
 ## II - 3. Solana transactions
 
-Keystone has proposed and implemented the specific UR types `sol-sign-request` and `sol-signature` for signing Solana transactions in [[solana-qr-data-protocol]](https://github.com/KeystoneHQ/Keystone-developer-hub/blob/main/research/solana-qr-data-protocol.md#sending-the-unsigned-data-from-wallet-only-wallet-to-offline-signer). In this document, we present their integration into the common UR types `crypto-sign-request` and `crypto-signature`.
+Keystone has proposed and implemented the specific UR types `sol-sign-request` and `sol-signature` for signing Solana transactions in [[solana-qr-data-protocol]](https://github.com/KeystoneHQ/Keystone-developer-hub/blob/main/research/solana-qr-data-protocol.md#sending-the-unsigned-data-from-wallet-only-wallet-to-offline-signer). In this document, we present their integration into the common UR types `sign-request` and `crypto-signature`.
 
 ### Integration with the generic UR types registry
 
@@ -801,9 +801,9 @@ Additionally, the following fields are recommended to be supplied by the watch-o
 - Type of data to sign, if not specified, transaction type is used by default
 - Origin of the sign request
 
-The following table indicates the corresponding fields between the UR types `sol-sign-request` and `crypto-sign-request`.
+The following table indicates the corresponding fields between the UR types `sol-sign-request` and `sign-request`.
 
-| crypto-sign-request fields <br> Associated number corresponds to the order in UR type | Corresponding sol-sign-request fields <br> Associated number corresponds to the order in UR type |
+| sign-request fields <br> Associated number corresponds to the order in UR type | Corresponding sol-sign-request fields <br> Associated number corresponds to the order in UR type |
 | --- | --- |
 | 1. request-id (optional) | 1. request-id (optional) |
 | 2. coin-id | No corresponding field, serves as identifier for SOL transactions |
@@ -813,7 +813,7 @@ The following table indicates the corresponding fields between the UR types `sol
 | 6.1. sol-meta.data-type (optional, transaction type by default) | 6. type (optional, transaction type by default) |
 | 6.2. sol-meta.address (optional) | 4. address (optional, completing the provided derivation path for account identification) |
 
-`crypto-sign-request` UR type provides the exact same information as `sol-sign-request` with the advantage of `crypto-sign-request` to be blockchain-agnostic.
+`sign-request` UR type provides the exact same information as `sol-sign-request` with the advantage of `sign-request` to be blockchain-agnostic.
 
 - **Solana signature**
 
@@ -833,7 +833,7 @@ The following table indicates the corresponding fields between the UR types `sol
 
 ### Use case
 
-The watch-only wallet generates a QR code containing the `crypto-sign-request` UR type with the following information:
+The watch-only wallet generates a QR code containing the `sign-request` UR type with the following information:
 
 1. (Recommended) Request ID, an universally unique identifier (UUID) of the transaction
 2. Solana coin identity
@@ -926,7 +926,7 @@ A6                                      # map(6)
 - UR encoding
 
 ```
-ur:crypto-sign-request/A601D825509B1DEB4D3B7D4BAD9BDD2B0D7B3DCB6D02D90579A20106021901F503D99D70A20188182CF51901F5F500F500F5021A37B5EED404589601000103C8D842A2F17FD7AAB608CE2EA535A6E958DFFA20CAF669B347B911C4171965530F957620B228BAE2B94C82DDD4C093983A67365555B737EC7DDC1117E61C72E0000000000000000000000000000000000000000000000000000000000000000010295CC2F1F39F3604718496EA00676D6A72EC66AD09D926E3ECE34F565F18D201020200010C0200000000E1F50500000000056D4E4752415645204C495155494406D9058DA2010102782C39465065624B44475A4164637054375370664231556F7775716F6256385A7777395477504453797A584A4D72
+ur:sign-request/A601D825509B1DEB4D3B7D4BAD9BDD2B0D7B3DCB6D02D90579A20106021901F503D99D70A20188182CF51901F5F500F500F5021A37B5EED404589601000103C8D842A2F17FD7AAB608CE2EA535A6E958DFFA20CAF669B347B911C4171965530F957620B228BAE2B94C82DDD4C093983A67365555B737EC7DDC1117E61C72E0000000000000000000000000000000000000000000000000000000000000000010295CC2F1F39F3604718496EA00676D6A72EC66AD09D926E3ECE34F565F18D201020200010C0200000000E1F50500000000056D4E4752415645204C495155494406D9058DA2010102782C39465065624B44475A4164637054375370664231556F7775716F6256385A7777395477504453797A584A4D72
 ```
 
 </details>
@@ -988,7 +988,7 @@ In case of more complex transactions, the offline signer should be able to recog
 
 ## II - 4. Tezos transactions
 
-[[TZIP-25]](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-25/tzip-25.md) proposes the specific UR types `xtz-sign-request` and `xtz-signature` for signing Tezos transactions. In this document, we present their integration into the common UR types `crypto-sign-request` and `crypto-signature`.
+[[TZIP-25]](https://gitlab.com/tezos/tzip/-/blob/master/proposals/tzip-25/tzip-25.md) proposes the specific UR types `xtz-sign-request` and `xtz-signature` for signing Tezos transactions. In this document, we present their integration into the common UR types `sign-request` and `crypto-signature`.
 
 ### Integration with the generic UR types registry
 
@@ -1007,9 +1007,9 @@ Additionally, the following fields are recommended to be supplied by the watch-o
 - Type of data to sign, if not specified, operation type is used by default
 - Origin of the sign request
 
-The following table indicates the corresponding fields between the UR types `xtz-sign-request` and `crypto-sign-request`.
+The following table indicates the corresponding fields between the UR types `xtz-sign-request` and `sign-request`.
 
-| crypto-sign-request fields <br> Associated number corresponds to the order in UR type | Corresponding xtz-sign-request fields <br> Associated number corresponds to the order in UR type |
+| sign-request fields <br> Associated number corresponds to the order in UR type | Corresponding xtz-sign-request fields <br> Associated number corresponds to the order in UR type |
 | --- | --- |
 | 1. request-id (optional) | 1. request-id (optional) |
 | 2. coin-id specifying the elliptic curve for XTZ | 5. key-type   |
@@ -1018,7 +1018,7 @@ The following table indicates the corresponding fields between the UR types `xtz
 | 5. origin (optional) | No corresponding field, provides an additional description |
 | 6.1. xtz-meta.data-type (optional) | 3. data-type |
 
-`crypto-sign-request` UR type provides the exact same information as `xtz-sign-request` and has even the advantage to provide an additional optional field with a text describing the origin (e.g. the wallet name).
+`sign-request` UR type provides the exact same information as `xtz-sign-request` and has even the advantage to provide an additional optional field with a text describing the origin (e.g. the wallet name).
 
 - **Tezos signature**
 
@@ -1040,7 +1040,7 @@ Additionally, `crypto-signature` has the advantage to provide an additional opti
 
 ### Use case
 
-The watch-only wallet generates a QR code containing the `crypto-sign-request` UR type with the following information:
+The watch-only wallet generates a QR code containing the `sign-request` UR type with the following information:
 
 1. (Recommended) Request ID, an universally unique identifier (UUID) of the transaction
 2. Tezos coin identity with the specific elliptic curve
@@ -1133,7 +1133,7 @@ A6                                      # map(6)
 
 - UR encoding
 ```
-ur:crypto-sign-request/headlkhttgglgenktepyeosyheglmekncyenptlecyaolebedwhdadbdaoftbdleatlegtckhdadfeetkkpkftbdlepkaepkaepkaepkbefwnehnntlgasbksyphsoecfdbtettncbgwaefeinclfkaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeechdeycebmcwcelpaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaebdaeadecececbecytnspvtrsahsehtspsoutzmsorebdlebefthdadadaodnhecedtlncdspzodnmwbedncholcetgrsbtcbceutahzmbsdndtnsrkbepnutdwdtdtzmlnbedt
+ur:sign-request/headlkhttgglgenktepyeosyheglmekncyenptlecyaolebedwhdadbdaoftbdleatlegtckhdadfeetkkpkftbdlepkaepkaepkaepkbefwnehnntlgasbksyphsoecfdbtettncbgwaefeinclfkaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeechdeycebmcwcelpaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaebdaeadecececbecytnspvtrsahsehtspsoutzmsorebdlebefthdadadaodnhecedtlncdspzodnmwbedncholcetgrsbtcbceutahzmbsdndtnsrkbepnutdwdtdtzmlnbedt
 ```
 
 </details>
@@ -1192,7 +1192,7 @@ Smart contracts decoding on Tezos are not addressed in this document.
 
 ## II - 5. Other blockchains transactions
 
-There are no existing signing protocol based on UR types for other blockchains (at the time of writing). This document introduces the signing of MultiversX and Stellar transactions as examples for the blockchain-agnostic `crypto-sign-request` and `crypto-signature` UR types introduced.
+There are no existing signing protocol based on UR types for other blockchains (at the time of writing). This document introduces the signing of MultiversX and Stellar transactions as examples for the blockchain-agnostic `sign-request` and `crypto-signature` UR types introduced.
 
 ### Integration with the generic UR types registry
 
@@ -1210,7 +1210,7 @@ Additionally, the following fields are recommended to be supplied by the watch-o
 - Unique request identifier
 - Origin of the sign request
 
-The listed information for requesting a MultiversX or Stellar signature can be included in the `crypto-sign-request` UR type. 
+The listed information for requesting a MultiversX or Stellar signature can be included in the `sign-request` UR type. 
 
 - **MultiversX and Stellar signature**
 
@@ -1303,7 +1303,7 @@ A5                                      # map(5)
 
 - UR encoding 
 ```
-ur:crypto-sign-request/hmadlkhttgglgenktepyeosyheglmekncyenptlecyaolehljnhdadbdaoftadpkatlegtckhdadfeetkkpkftadpkpkaepkaepkadpkaofwnehnntlgasbksyphsoecfdbtettncbgwaefeinclfkaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeechdeycebmcwcelpaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaebdaeadecececbecytnspvtrsahsehtspsoutzmsore
+ur:sign-request/hmadlkhttgglgenktepyeosyheglmekncyenptlecyaolehljnhdadbdaoftadpkatlegtckhdadfeetkkpkftadpkpkaepkaepkadpkaofwnehnntlgasbksyphsoecfdbtettncbgwaefeinclfkaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeechdeycebmcwcelpaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaebdaeadecececbecytnspvtrsahsehtspsoutzmsore
 ```
 
 </details>
@@ -1411,7 +1411,7 @@ A5                                      # map(5)
 - UR encoding
 
 ```
-ur:crypto-sign-request/hmadlkhttgglgenktepyeosyheglmekncyenptlecyaolehljnhdadbdaoetfkatlegtckhdadfeetkkpketfkpkaepkaepkaopkbefwnehnntlgasbkgwaeaeaeaoaeaeaeaekgorcdbelyfdcyfelnierssycfmkvthtpttpzohekeglpsfeorlnknpslemtlecyaeaeaebsaecnhemkaeaeaeadaeaeaeadaeaeaeaeaeaeaebsaeaeaeaebsctfezmaeaeaeadaeaeaecfspbmcmcmcdhtadcdcbcmbshkaeaeaeadaeaeaeaeaeaeaeadaeaeaeaelpftcnneeedmbslpdrhlbkhebplkcxbkvtldgngmcblnmlbelpftnlpnbkdnlkjnaeaeaeaeaeaeaeaozobbmeaeaeaeaeaeaeaeaeaebdcytnspvtrsahsehtspsoutzmsore
+ur:sign-request/hmadlkhttgglgenktepyeosyheglmekncyenptlecyaolehljnhdadbdaoetfkatlegtckhdadfeetkkpketfkpkaepkaepkaopkbefwnehnntlgasbkgwaeaeaeaoaeaeaeaekgorcdbelyfdcyfelnierssycfmkvthtpttpzohekeglpsfeorlnknpslemtlecyaeaeaebsaecnhemkaeaeaeadaeaeaeadaeaeaeaeaeaeaebsaeaeaeaebsctfezmaeaeaeadaeaeaecfspbmcmcmcdhtadcdcbcmbshkaeaeaeadaeaeaeaeaeaeaeadaeaeaeaelpftcnneeedmbslpdrhlbkhebplkcxbkvtldgngmcblnmlbelpftnlpnbkdnlkjnaeaeaeaeaeaeaeaozobbmeaeaeaeaeaeaeaeaeaebdcytnspvtrsahsehtspsoutzmsore
 ```
 
 </details>

--- a/papers/nbcr-2023-003-crypto-sign.md
+++ b/papers/nbcr-2023-003-crypto-sign.md
@@ -6,7 +6,7 @@
 Authors: Mathieu Da Silva, Irfan Bilaloglu <br/>
 Date: April 26, 2023
 
-Revised: September 25, 2024
+Revised: October 04, 2024
 
 ---
 
@@ -309,7 +309,7 @@ This document aims to propose common UR types for signing on every blockchain.
 
 This UR type is tagged with #6.1411 and embeds:
 
-- The `crypto-coin-identity` UR type tagged with #6.140 and introduced in [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md). This UR type identifies the elliptic curve and the blockchain on which the sign request is initiated.
+- The `coin-identity` UR type tagged with #6.140 and introduced in [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md). This UR type identifies the elliptic curve and the blockchain on which the sign request is initiated.
 - An optional UR type to specify metadata related to a specific coin.
 
 ```
@@ -319,7 +319,7 @@ coin-meta = #6.1420(eth-meta) / #6.1421(sol-meta) / #6.1422(xtz-meta)
 
 crypto-sign-request = {
     ?request-id: uuid,                        ; Identifier of the signing request
-    coin-id: #6.1401(crypto-coin-identity),   ; Provides information on the elliptic curve and the blockchain/coin
+    coin-id: #6.441401(coin-identity),   ; Provides information on the elliptic curve and the blockchain/coin
     ?derivation-path: #6.40304(keypath),      ; Key path for signing this request
     sign-data: bytes,                         ; Transaction to be decoded by the offline signer 
     ?origin: text,                            ; Origin of this sign request, e.g. wallet name
@@ -376,7 +376,7 @@ Since Bitcoin transactions follow [[BIP174]](https://github.com/bitcoin/bips/blo
 
 - **Bitcoin sign request**
 
-A Bitcoin transaction is uniquely identified thanks to the information shared in `crypto-coin-identity` UR type, i.e. secp256k1 as elliptic curve and 0 as coin type. 
+A Bitcoin transaction is uniquely identified thanks to the information shared in `coin-identity` UR type, i.e. secp256k1 as elliptic curve and 0 as coin type. 
 
 The only other required field for requesting the signature of a Bitcoin transaction is the bytes composing the unsigned PSBT transaction, corresponding to the `sign-data` field of `crypto-sign-request` UR type.
 
@@ -455,7 +455,7 @@ An example illustrates how the signature request and response for Bitcoin PSBT a
 ```
 {
 1: 37(h'3B5414375E3A450B8FE1251CBC2B3FB5'), ; request-id
-2: 1401( ; #6.1401(crypto-coin-identity)
+2: 41401( ; #6.41401(coin-identity)
     {1: 8, ; secp256k1 curve
      2: 0 ; Bitcoin BIP44
     }),
@@ -475,7 +475,7 @@ A5                                      # map(5)
       50                                # bytes(16)
          3B5414375E3A450B8FE1251CBC2B3FB5 
    02                                   # unsigned(2)
-   D9 0579                              # tag(1401)
+   D9 A1B9                              # tag(41401)
       A2                                # map(2)
          01                             # unsigned(1)
          08                             # unsigned(8)
@@ -509,7 +509,7 @@ A5                                      # map(5)
 - UR encoding 
 
 ```
-ur:crypto-sign-request/hmadlkhttgpyzoddnebwptsebbfpmkhtfljtknrnhnaolebedwhdadbraoaeatlegtckhdadfeetkkpkaepkaepkaepraepraofwnehnntlgasbkheckcwbkcepyadaegtaoaeaeaeaobknldthkhncyhtcfhekkftckcksecmmecdeyjehmlndndwhepksefeenhyhpmednaeaeaeaeaepypypypyfmfgasinldndbmbpcthtsdjpbbbtfenrrehekecthyltdnmhjybkdwbeldeynrgeadaeaeaeaepypypypyaockhtonbraeaeaeaedmaeddlkblknctldbdbbbtldfechnkenbwtggpgemlcxteaemkpkbeaeaeaeaedmaeddaehlhrhdmeonphdthmfemdzmsdnlcekggeflaefpaeaeaeaeaeaeaeaeaebecytnspvtrsahsehtspsoutzmsore
+ur:crypto-sign-request/hmadlkhttgpyzoddnebwptsebbfpmkhtfljtknrnhnaolehljnhdadbraoaeatlegtckhdadfeetkkpkaepkaepkaepraepraofwnehnntlgasbkheckcwbkcepyadaegtaoaeaeaeaobknldthkhncyhtcfhekkftckcksecmmecdeyjehmlndndwhepksefeenhyhpmednaeaeaeaeaepypypypyfmfgasinldndbmbpcthtsdjpbbbtfenrrehekecthyltdnmhjybkdwbeldeynrgeadaeaeaeaepypypypyaockhtonbraeaeaeaedmaeddlkblknctldbdbbbtldfechnkenbwtggpgemlcxteaemkpkbeaeaeaeaedmaeddaehlhrhdmeonphdthmfemdzmsdnlcekggeflaefpaeaeaeaeaeaeaeaeaebecytnspvtrsahsehtspsoutzmsore
 ```
 
 </details>
@@ -573,7 +573,7 @@ The received PSBT should be decoded by the offline signer to know each input and
 
 - **Ethereum sign request**
 
-An Ethereum transaction is uniquely identified thanks to the information shared in `crypto-coin-identity` UR type, i.e. secp256k1 as elliptic curve, 60 as coin type and chain ID as subtype to identify the EVM chain (e.g. 1 for Ethereum).
+An Ethereum transaction is uniquely identified thanks to the information shared in `coin-identity` UR type, i.e. secp256k1 as elliptic curve, 60 as coin type and chain ID as subtype to identify the EVM chain (e.g. 1 for Ethereum).
 
 Several fields are required for requesting the signature of an Ethereum transaction:
 
@@ -648,7 +648,7 @@ An example illustrates how the signing protocol works on EVM blockchains:
 ```
 {
 1: 37(h'9b1deb4d3b7d4bad9bdd2b0d7b3dcb6d'), ; request-id
-2: 1401( ; #6.1401(crypto-coin-identity)
+2: 41401( ; #6.41401(coin-identity)
     {1: 8, ; secp256k1 curve
      2: 60, ; Ethereum BIP44
      3: 137 ; Polygon chain ID
@@ -788,7 +788,7 @@ Keystone has proposed and implemented the specific UR types `sol-sign-request` a
 
 - **Solana sign request**
 
-A Solana transaction is uniquely identified thanks to the information shared in `crypto-coin-identity` UR type, i.e. ed25519 as elliptic curve and 501 as coin type.
+A Solana transaction is uniquely identified thanks to the information shared in `coin-identity` UR type, i.e. ed25519 as elliptic curve and 501 as coin type.
 
 Several fields are required for requesting the signature of a Solana transaction:
 
@@ -862,7 +862,7 @@ An example illustrates how the signing protocol works on Solana blockchain:
 ```
 {
 1: 37(h'9b1deb4d3b7d4bad9bdd2b0d7b3dcb6d'), ; request-id
-2: 1401( ; #6.1401(crypto-coin-identity)
+2: 41401( ; #6.41401(coin-identity)
     {1: 6, ; ed25519 curve
      2: 501 ; Solana BIP44
     }),
@@ -994,7 +994,7 @@ In case of more complex transactions, the offline signer should be able to recog
 
 - **Tezos sign request**
 
-A Tezos transaction is uniquely identified thanks to `crypto-coin-identity` UR type, indicating which elliptic curve should be used (either secp256k1, ed25519 or P256) for the coin type 1729.
+A Tezos transaction is uniquely identified thanks to `coin-identity` UR type, indicating which elliptic curve should be used (either secp256k1, ed25519 or P256) for the coin type 1729.
 
 Several fields are required for requesting the signature of a Tezos transaction:
 
@@ -1068,7 +1068,7 @@ An example illustrates how the signing protocol works on Tezos blockchain:
 ```
 {
 1: 37(h'9b1deb4d3b7d4bad9bdd2b0d7b3dcb6d'), ; request-id
-2: 1401( ; #6.1401(crypto-coin-identity)
+2: 41401( ; #6.41401(coin-identity)
     {1: 6, ; ed25519 curve
      2: 1729 ; Tezos BIP44
     }),
@@ -1198,7 +1198,7 @@ There are no existing signing protocol based on UR types for other blockchains (
 
 - **MultiversX and Stellar sign request**
 
-A MultiversX transaction is uniquely identified thanks to `crypto-coin-identity` UR type, i.e. ed25519 as elliptic curve and 508 as coin type. Identically, a Stellar transaction is identified with ed25519 as an elliptic curve and 148 as a coin type.
+A MultiversX transaction is uniquely identified thanks to `coin-identity` UR type, i.e. ed25519 as elliptic curve and 508 as coin type. Identically, a Stellar transaction is identified with ed25519 as an elliptic curve and 148 as a coin type.
 
 Several fields are required for requesting the signature of a MultiversX or Stellar transaction:
 
@@ -1250,7 +1250,7 @@ An example illustrates how the signing protocol works on MultiversX blockchain:
 ```
 {
 1: 37(h'9b1deb4d3b7d4bad9bdd2b0d7b3dcb6d'), ; request-id
-2: 1401( ; #6.1401(crypto-coin-identity)
+2: 41401( ; #6.41401(coin-identity)
     {1: 6, ; ed25519 curve
      2: 501 ; MultiversX BIP44
     }),
@@ -1268,9 +1268,9 @@ A5                                      # map(5)
    01                                   # unsigned(1)
    D8 25                                # tag(37)
       50                                # bytes(16)
-         9B1DEB4D3B7D4BAD9BDD2B0D7B3DCB6D
+         9B1DEB4D3B7D4BAD9BDD2B0D7B3DCB6D 
    02                                   # unsigned(2)
-   D9 0579                              # tag(1401)
+   D9 A1B9                              # tag(41401)
       A2                                # map(2)
          01                             # unsigned(1)
          06                             # unsigned(6)
@@ -1295,7 +1295,7 @@ A5                                      # map(5)
          1A 37B5EED4                    # unsigned(934670036)
    04                                   # unsigned(4)
    58 4B                                # bytes(75)
-      F849808609184E72A00082271094000000000000000000000000000000000000000080A47F7465737432000000000000000000000000000000000000000000000000000000600057808080 
+      F849808609184E72A00082271094000000000000000000000000000000000000000080A47F7465737432000000000000000000000000000000000000000000000000000000600057808080
    05                                   # unsigned(5)
    6D                                   # text(13)
       4E4752415645204C4951554944        # "NGRAVE LIQUID"
@@ -1303,7 +1303,7 @@ A5                                      # map(5)
 
 - UR encoding 
 ```
-ur:crypto-sign-request/hmadlkhttgglgenktepyeosyheglmekncyenptlecyaolebedwhdadbdaoftadpkatlegtckhdadfeetkkpkftadpkpkaepkaepkadpkaofwnehnntlgasbksyphsoecfdbtettncbgwaefeinclfkaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeechdeycebmcwcelpaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaebdaeadecececbecytnspvtrsahsehtspsoutzmsore
+ur:crypto-sign-request/hmadlkhttgglgenktepyeosyheglmekncyenptlecyaolehljnhdadbdaoftadpkatlegtckhdadfeetkkpkftadpkpkaepkaepkadpkaofwnehnntlgasbksyphsoecfdbtettncbgwaefeinclfkaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeechdeycebmcwcelpaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaebdaeadecececbecytnspvtrsahsehtspsoutzmsore
 ```
 
 </details>
@@ -1357,7 +1357,7 @@ Another example illustrates how the signing protocol works on Stellar blockchain
 ```
 {
 1: 37(h'9b1deb4d3b7d4bad9bdd2b0d7b3dcb6d'), ; request-id
-2: 1401( ; #6.1401(crypto-coin-identity)
+2: 41401( ; #6.41401(coin-identity)
     {1: 6, ; ed25519 curve
      2: 148 ; Stellar BIP44
     }),
@@ -1375,9 +1375,9 @@ A5                                      # map(5)
    01                                   # unsigned(1)
    D8 25                                # tag(37)
       50                                # bytes(16)
-         9B1DEB4D3B7D4BAD9BDD2B0D7B3DCB6D 
+         9B1DEB4D3B7D4BAD9BDD2B0D7B3DCB6D # "\x9B\u001D\xEBM;}K\xAD\x9B\xDD+\r{=\xCBm"
    02                                   # unsigned(2)
-   D9 0579                              # tag(1401)
+   D9 A1B9                              # tag(41401)
       A2                                # map(2)
          01                             # unsigned(1)
          06                             # unsigned(6)
@@ -1411,7 +1411,7 @@ A5                                      # map(5)
 - UR encoding
 
 ```
-ur:crypto-sign-request/hmadlkhttgglgenktepyeosyheglmekncyenptlecyaolebedwhdadbdaoetfkatlegtckhdadfeetkkpketfkpkaepkaepkaopkbefwnehnntlgasbkgwaeaeaeaoaeaeaeaekgorcdbelyfdcyfelnierssycfmkvthtpttpzohekeglpsfeorlnknpslemtlecyaeaeaebsaecnhemkaeaeaeadaeaeaeadaeaeaeaeaeaeaebsaeaeaeaebsctfezmaeaeaeadaeaeaecfspbmcmcmcdhtadcdcbcmbshkaeaeaeadaeaeaeaeaeaeaeadaeaeaeaelpftcnneeedmbslpdrhlbkhebplkcxbkvtldgngmcblnmlbelpftnlpnbkdnlkjnaeaeaeaeaeaeaeaozobbmeaeaeaeaeaeaeaeaeaebdcytnspvtrsahsehtspsoutzmsore
+ur:crypto-sign-request/hmadlkhttgglgenktepyeosyheglmekncyenptlecyaolehljnhdadbdaoetfkatlegtckhdadfeetkkpketfkpkaepkaepkaopkbefwnehnntlgasbkgwaeaeaeaoaeaeaeaekgorcdbelyfdcyfelnierssycfmkvthtpttpzohekeglpsfeorlnknpslemtlecyaeaeaebsaecnhemkaeaeaeadaeaeaeadaeaeaeaeaeaeaebsaeaeaeaebsctfezmaeaeaeadaeaeaecfspbmcmcmcdhtadcdcbcmbshkaeaeaeadaeaeaeaeaeaeaeadaeaeaeaelpftcnneeedmbslpdrhlbkhebplkcxbkvtldgngmcblnmlbelpftnlpnbkdnlkjnaeaeaeaeaeaeaeaozobbmeaeaeaeaeaeaeaeaeaebdcytnspvtrsahsehtspsoutzmsore
 ```
 
 </details>

--- a/papers/nbcr-2024-001-unique-asset-id.md
+++ b/papers/nbcr-2024-001-unique-asset-id.md
@@ -95,7 +95,7 @@ The UR types and the UAI format can easily be converted to each other:
 
 - `coin-identity` UR type defined in [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md) contains the same mandatory UAI fields, i.e. the curve, the type and the subtypes. 
 
-- `crypto-detailed-accounts` UR type defined in [[NBCR-2023-002]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-002-multi-layer-sync.md) contains the same optional UAI fields, i.e. the token ID and the derivation path.
+- `detailed-account` UR type defined in [[NBCR-2023-002]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-002-multi-layer-sync.md) contains the same optional UAI fields, i.e. the token ID and the derivation path.
 
 We provide an example how UR types and UAI format can be converted to each other:
 
@@ -105,7 +105,7 @@ We provide an example how UR types and UAI format can be converted to each other
 uai://secp256k1.60.137:0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359/44h/60h/0h/1/0?master_fingerprint=2819587291
      |_______________| |_____________________________________________________________________________________|
               |                                     |
-      coin-identity                       crypto-detailed-accounts
+      coin-identity                       detailed-account
 
 CBOR diagnostic notation          
       {                                   {

--- a/papers/nbcr-2024-001-unique-asset-id.md
+++ b/papers/nbcr-2024-001-unique-asset-id.md
@@ -6,6 +6,8 @@
 Authors: İrfan Bilaloğlu, Mathieu Da Silva, Maher Sallam<br/>
 Date: 18 September 2024<br/>
 
+Revised: October 04, 2024
+
 ---
 
 ### Introduction
@@ -91,7 +93,7 @@ The UAI format and the UR types defined in [[NBCR-2023-001]](https://github.com/
 
 The UR types and the UAI format can easily be converted to each other:
 
-- `crypto-coin-identity` UR type defined in [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md) contains the same mandatory UAI fields, i.e. the curve, the type and the subtypes. 
+- `coin-identity` UR type defined in [[NBCR-2023-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-001-coin-identity.md) contains the same mandatory UAI fields, i.e. the curve, the type and the subtypes. 
 
 - `crypto-detailed-accounts` UR type defined in [[NBCR-2023-002]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2023-002-multi-layer-sync.md) contains the same optional UAI fields, i.e. the token ID and the derivation path.
 
@@ -103,7 +105,7 @@ We provide an example how UR types and UAI format can be converted to each other
 uai://secp256k1.60.137:0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359/44h/60h/0h/1/0?master_fingerprint=2819587291
      |_______________| |_____________________________________________________________________________________|
               |                                     |
-      crypto-coin-identity                crypto-detailed-accounts
+      coin-identity                       crypto-detailed-accounts
 
 CBOR diagnostic notation          
       {                                   {


### PR DESCRIPTION
We want to align the newly introduced UR types with the new BC UR types:
These are the list of changes applied to all the papers:
- crypto-coin-identity (`#6.1401`) → coin-identity (`#6.41401`)
- crypto-detailed-account (`#6.1402`) → detailed-account (`#6.41402`)
- crypto-portfolio-coin (`#6.1403`) → portfolio-coin (`#6.41403`)
- crypto-portfolio-metadata (`#6.1404`) → portfolio-metadata (`#6.41404`)
- crypto-portfolio (`#6.1405`) → portfolio (`#6.41405`)
- crypto-sign-request (`#6.1411`) → sign-request (`#6.41411`)
- crypto-signature (`#6.1412`) → sign-response (`#6.41412`)

The idea is in a later stage to register these new types to [IANA registry](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml) where 40804-42599 is an unassigned area.
