### PR TITLE
feat(nbcr-2023-002): adopt hex-string + UAI dot form for token-ids

### DIFF
--- a/papers/nbcr-2023-002-multi-layer-sync.md
+++ b/papers/nbcr-2023-002-multi-layer-sync.md
@@ -7,7 +7,7 @@
 Authors: Mathieu Da Silva, Irfan Bilaloglu <br/>
 Date: April 19, 2023
 
-Revised: October 04, 2024
+Revised: April 23, 2026
 
 ---
 
@@ -487,36 +487,43 @@ In this document, we are defining the new `detailed-account` UR type, extending 
 This new type aims to incorporate in the same structure:
 
 - The accounts with and without scripts by selecting either `hdkey` or `output-descriptor`. When a `hdkey` is embedded inside `detailed-account`, the optional `coin-info` in `hdkey` should **not** be defined since `detailed-account` is used in combination with `coin-identity` used already as asset identifier. 
-- An optional list of tokens to synchronize them at the same time of the associated account. A token identifier is defined either as a string or as bytes.
+- An optional list of tokens to synchronize at the same time of the associated account. A token identifier is either a plain text string (`tstr`) or a hexadecimal byte string wrapped in IANA CBOR tag 263 ([`hex-string`](https://github.com/toravir/CBOR-Tag-Specs/blob/master/hexString.md)). The `hex-string` form roughly halves the on-wire size for canonically hex identifiers such as EVM contract addresses. Compound identifiers (e.g. ERC-721 / ERC-1155) follow the Unique Asset Identifier convention from [[NBCR-2024-001]](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2024-001-unique-asset-id.md), using `tokenid[.subtype...]`.
 
 The following specification of `detailed-account` is written in CDDL. When used embedded in another CBOR structure, this structure should be tagged #6.41402.
 
 ```
 account_exp = #6.40303(hdkey) / #6.40308(output-descriptor)
+hex-string = #6.263(bstr)
 
-; Accounts are specified using either '#6.40303(hdkey)' or 
+; Accounts are specified using either '#6.40303(hdkey)' or
 ; '#6.40308(output-descriptor)'.
 ; By default, '#6.40303(hdkey)' should be used to share public keys and
 ; extended public keys.
-; '#6.308(output-descriptor)' should be used to share an output descriptor, 
+; '#6.40308(output-descriptor)' should be used to share an output descriptor,
 ; e.g. for the different Bitcoin address formats (P2PKH, P2SH-P2WPKH, P2WPKH, P2TR).
+;
+; 'hex-string' (IANA CBOR tag 263) wraps bytes meant to be read as a hexadecimal
+; string; the tag preserves hex semantics for display and comparison, while
+; halving the on-wire size compared to the equivalent "0x..." text.
 
 ; Optional 'token-ids' to indicate the synchronization of a list of tokens with
-; the associated accounts
-; 'token-id' is defined differently depending on the blockchain:
-; - ERC20 tokens on EVM chains are identified by their contract addresses 
-; (e.g. `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`)
-; - ERC1155 tokens are identifed with their contract addresses followed by their 
-; ID with ':' as separator (e.g. `0xfaafdc07907ff5120a76b34b731b278c38d6043c:
-; 508851954656174721695133294256171964208`)
-; - ESDT tokens on MultiversX are by their name followed by their ID with `-` as 
-; separator (e.g. `USDC-c76f1f`)
-; - SPL tokens on Solana are identified by their contract addresses
-; (e.g. `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`)
+; the associated accounts.
+; 'token-id' encoding follows the Unique Asset Identifier (UAI) convention
+; defined in [NBCR-2024-001]. A token-id is either a scalar identifier or a
+; compound "parent.subtype[.subtype...]" form. Current encodings per blockchain:
+; - ERC20 tokens on EVM chains are identified by their contract addresses,
+;   encoded as 'hex-string' (e.g. `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`).
+; - ERC721 / ERC1155 tokens are identified by contract address plus token id,
+;   encoded as tstr using the UAI "contract.tokenId" form (e.g.
+;   `0xfaafdc07907ff5120a76b34b731b278c38d6043c.508851954656174721695133294256171964208`).
+; - ESDT fungible tokens on MultiversX are identified by a ticker-hex
+;   identifier, encoded as tstr (e.g. `USDC-c76f1f`).
+; - SPL / Token-2022 on Solana are identified by their mint address,
+;   encoded as tstr (e.g. `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`).
 
-detailed-account = { 
+detailed-account = {
   account: account_exp,
-  ? token-ids: [+ string] ; Specify multiple tokens associated to one account
+  ? token-ids: [+ tstr / hex-string] ; Specify multiple tokens associated to one account
 }
 
 account = 1
@@ -1360,3 +1367,6 @@ The information shared with the watch-only wallet can be altered on the device r
 | [BIP32] | https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki |
 | [SLIP44]  | https://github.com/satoshilabs/slips/blob/master/slip-0044.md |
 | [OD-IN-CORE] | https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md |
+| [NBCR-2024-001] | https://github.com/ngraveio/Research/blob/main/papers/nbcr-2024-001-unique-asset-id.md |
+| [hexString] | https://github.com/toravir/CBOR-Tag-Specs/blob/master/hexString.md |
+| [EIP-1155] | https://eips.ethereum.org/EIPS/eip-1155 |


### PR DESCRIPTION
## Summary

Aligns `detailed-account` (NBCR-2023-002, Layer 3) with:

1. **`hex-string = #6.263(bstr)`** (IANA CBOR tag 263) as an alternative encoding for canonically hex token identifiers, primarily EVM contract addresses.
2. **UAI `.` separator** (per [NBCR-2024-001](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2024-001-unique-asset-id.md)) for compound identifiers such as ERC-721 / ERC-1155.

`tstr` remains valid. Previously-emitted payloads decode unchanged.

## On-wire impact

For an EVM ERC-20 contract address (20 bytes on-chain, 42 characters as `0x…` text):

| Encoding | On wire | Savings |
|---|---|---|
| `tstr` (previous) | ~44 bytes | baseline |
| `hex-string` (tag 263) | ~24 bytes | ~20 bytes / ~45% |

A portfolio with 20 ERC-20 identifiers saves ~400 bytes total, often enough to drop one or two animated-QR frames from a sync flow (recommended fragment size is 200 characters per QR).

## Parser impact

Tag `41402` (`detailed-account`) and the keymap (`account = 1`, `token-ids = 2`) are **unchanged**. The change is additive: one new alternative inside the `token-ids` array union.

- **Legacy `tstr` path decodes as before.** No action needed for backward compatibility.
- **Parsers SHOULD now recognise CBOR tag 263** wrapping a `bstr` inside `token-ids`. The wrapped bytes are the hex-interpreted identifier (20 bytes for an EVM contract address; variable for future encodings). Display layers render with a `0x` prefix, lowercase, preserving round-trip parity with the caller's input.
- **C parser action items (embedded, ZERO side):**
  1. Add a handler for CBOR tag 263 wherever `token-ids` entries are consumed.
  2. Surface the wrapped bytes with a "hex-interpreted" flag so the UI renders `0x<lowercase hex>`.
  3. Keep the existing `tstr` path for non-hex identifiers (e.g. SPL mint addresses).
- **TypeScript reference implementation** in [`@ngraveio/ur-hex-string`](https://github.com/ngraveio/ur-registry/tree/main/ur-packages/hex-string), consumed by `DetailedAccount` in ngraveio/ur-registry#49.

## Backward compatibility

- Payloads emitted under the previous `[+ string]` grammar decode unchanged under `[+ tstr / hex-string]`.
- Legacy ERC-1155 identifiers using `:` (e.g. `0xabc:123`) remain decodable as `tstr`. The grammar does not constrain the separator; it is a prose convention. Producers SHOULD migrate to `.` to match UAI; consumers MAY continue accepting both during the transition.

## Other editorial changes

- Fix typo `#6.308(output-descriptor)` → `#6.40308(...)` in the CDDL comment (tag 308 is the deprecated `crypto-output`; the actual rule correctly uses 40308).
- Drop the "decimal" prescription on ERC-1155 token-id rendering. [EIP-1155](https://eips.ethereum.org/EIPS/eip-1155) defines `_id` as `uint256`; rendering is implementation choice.
- Tighten grammar from the under-specified `string` to RFC 8610's canonical `tstr`.
- Generalise the per-chain comments to cover ERC-721 alongside ERC-1155.
- Add references: NBCR-2024-001, hexString tag spec, EIP-1155.

## Not in this PR

- Layer 3 examples (around lines ~978, ~1013) still use the `tstr` form for ERC-20 addresses. They remain valid under the new spec; a follow-up can regenerate them to showcase `hex-string` (also touches the accompanying CBOR hex and UR encodings below each diagnostic example).
- A forward-looking structured array form `[hex-string, biguint]` for compound identifiers (separate proposal).
- IANA tag registration for non-EVM byte-string encodings like base58 and bech32, tracked separately.

## References

- [hexString CBOR tag 263 spec](https://github.com/toravir/CBOR-Tag-Specs/blob/master/hexString.md)
- [IANA CBOR tag registry](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml)
- [NBCR-2024-001 (UAI)](https://github.com/ngraveio/Research/blob/main/papers/nbcr-2024-001-unique-asset-id.md)
- [EIP-1155](https://eips.ethereum.org/EIPS/eip-1155)
- Companion impl: ngraveio/ur-registry#49